### PR TITLE
start moving DNS to environments

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -95,6 +95,8 @@ jobs:
       TF_VAR_aws_default_region: ((aws_external_region))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_development))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_development))
+      TF_VAR_commercial_aws_default_region: ((aws_external_region))
+      TF_VAR_commercial_assume_arn: ((commercial_assume_arn_development))
   - &notify-slack
     put: slack
     params:
@@ -150,6 +152,8 @@ jobs:
       TF_VAR_aws_default_region: ((aws_external_region))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_staging))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_staging))
+      TF_VAR_commercial_aws_default_region: ((aws_external_region))
+      TF_VAR_commercial_assume_arn: ((commercial_assume_arn_staging))
   - &notify-slack
     put: slack
     params:
@@ -205,6 +209,8 @@ jobs:
       TF_VAR_aws_default_region: ((aws_external_region))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_production))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_production))
+      TF_VAR_commercial_aws_default_region: ((aws_external_region))
+      TF_VAR_commercial_assume_arn: ((commercial_assume_arn_production))
   - *notify-slack
 
 - name: bootstrap-external-production

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -91,9 +91,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ((aws_external_secret_access_key))
       AWS_DEFAULT_REGION: ((aws_external_region))
       TF_VAR_stack_description: development
+      TF_VAR_domain: ((domain_development))
       TF_VAR_aws_default_region: ((aws_external_region))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_development))
-      TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_development))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_development))
   - &notify-slack
     put: slack
@@ -146,9 +146,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ((aws_external_secret_access_key))
       AWS_DEFAULT_REGION: ((aws_external_region))
       TF_VAR_stack_description: staging
+      TF_VAR_domain: ((domain_staging))
       TF_VAR_aws_default_region: ((aws_external_region))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_staging))
-      TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_staging))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_staging))
   - &notify-slack
     put: slack
@@ -201,9 +201,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ((aws_external_secret_access_key))
       AWS_DEFAULT_REGION: ((aws_external_region))
       TF_VAR_stack_description: production
+      TF_VAR_domain: ((domain_production))
       TF_VAR_aws_default_region: ((aws_external_region))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_production))
-      TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_production))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_production))
   - *notify-slack
 

--- a/terraform/modules/dns_zone/stack.tf
+++ b/terraform/modules/dns_zone/stack.tf
@@ -1,0 +1,17 @@
+provider aws {
+}
+provider aws {
+  alias = "apex"
+}
+resource "aws_route53_zone" "self_zone" {
+    name = var.domain
+}
+
+resource "aws_route53_record" "ns_record" {
+  provider  = aws.apex
+  zone_id   = var.parent_zone_id
+  name      = var.domain
+  type      = "NS"
+  ttl       = "30"
+  records   = aws_route53_zone.self_zone.name_servers
+}

--- a/terraform/modules/dns_zone/variables.tf
+++ b/terraform/modules/dns_zone/variables.tf
@@ -1,0 +1,8 @@
+
+variable "domain" {
+
+}
+
+variable "parent_zone_id" {
+
+}

--- a/terraform/modules/dns_zone/versions.tf
+++ b/terraform/modules/dns_zone/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/environment_dns/dns.tf
+++ b/terraform/modules/environment_dns/dns.tf
@@ -8,8 +8,12 @@ data "terraform_remote_state" "stack" {
   }
 }
 
+data "aws_route53_zone" "zone" {
+  name = var.domain
+}
+
 resource "aws_route53_record" "star_admin_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "*.${var.admin_subdomain}."
   type    = "A"
 
@@ -22,7 +26,7 @@ resource "aws_route53_record" "star_admin_a" {
 
 
 resource "aws_route53_record" "star_admin_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "*.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -34,7 +38,7 @@ resource "aws_route53_record" "star_admin_aaaa" {
 }
 
 resource "aws_route53_record" "star_app_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "*.${var.app_subdomain}."
   type    = "A"
 
@@ -46,7 +50,7 @@ resource "aws_route53_record" "star_app_a" {
 }
 
 resource "aws_route53_record" "star_app_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "*.${var.app_subdomain}."
   type    = "AAAA"
 
@@ -58,7 +62,7 @@ resource "aws_route53_record" "star_app_aaaa" {
 }
 
 resource "aws_route53_record" "admin_ui_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "admin.${var.admin_subdomain}."
   type    = "A"
 
@@ -70,7 +74,7 @@ resource "aws_route53_record" "admin_ui_a" {
 }
 
 resource "aws_route53_record" "admin_ui_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "admin.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -82,7 +86,7 @@ resource "aws_route53_record" "admin_ui_aaaa" {
 }
 
 resource "aws_route53_record" "uaa_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "uaa.${var.admin_subdomain}."
   type    = "A"
 
@@ -94,7 +98,7 @@ resource "aws_route53_record" "uaa_a" {
 }
 
 resource "aws_route53_record" "uaa_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "uaa.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -106,7 +110,7 @@ resource "aws_route53_record" "uaa_aaaa" {
 }
 
 resource "aws_route53_record" "login_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "login.${var.admin_subdomain}."
   type    = "A"
 
@@ -117,7 +121,7 @@ resource "aws_route53_record" "login_a" {
   }
 }
 resource "aws_route53_record" "login_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "login.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -129,7 +133,7 @@ resource "aws_route53_record" "login_aaaa" {
 }
 
 resource "aws_route53_record" "logs_platform_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "logs-platform.${var.admin_subdomain}."
   type    = "A"
 
@@ -141,7 +145,7 @@ resource "aws_route53_record" "logs_platform_a" {
 }
 
 resource "aws_route53_record" "logs_platform_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "logs-platform.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -153,7 +157,7 @@ resource "aws_route53_record" "logs_platform_aaaa" {
 }
 
 resource "aws_route53_record" "idp_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "idp.${var.admin_subdomain}."
   type    = "A"
 
@@ -165,7 +169,7 @@ resource "aws_route53_record" "idp_a" {
 }
 
 resource "aws_route53_record" "idp_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "idp.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -178,7 +182,7 @@ resource "aws_route53_record" "idp_aaaa" {
 
 
 resource "aws_route53_record" "ssh_a" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "ssh.${var.admin_subdomain}."
   type    = "A"
 
@@ -190,7 +194,7 @@ resource "aws_route53_record" "ssh_a" {
 }
 
 resource "aws_route53_record" "ssh_aaaa" {
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name    = "ssh.${var.admin_subdomain}."
   type    = "AAAA"
 
@@ -204,7 +208,7 @@ resource "aws_route53_record" "ssh_aaaa" {
 
 resource "aws_route53_record" "tcp_a" {
   for_each = toset(data.terraform_remote_state.stack.outputs.tcp_lb_dns_names)
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name = "tcp-${index(data.terraform_remote_state.stack.outputs.tcp_lb_dns_names, each.key)}.${var.domain}"
   type = "A"
   alias {
@@ -216,7 +220,7 @@ resource "aws_route53_record" "tcp_a" {
 
 resource "aws_route53_record" "tcp_aaaa" {
   for_each = toset(data.terraform_remote_state.stack.outputs.tcp_lb_dns_names)
-  zone_id = var.zone_id
+  zone_id = data.aws_route53_zone.zone.zone_id
   name = "tcp-${index(data.terraform_remote_state.stack.outputs.tcp_lb_dns_names, each.key)}.${var.domain}"
   type = "AAAA"
   alias {

--- a/terraform/modules/environment_dns/variables.tf
+++ b/terraform/modules/environment_dns/variables.tf
@@ -1,6 +1,3 @@
-variable "zone_id" {
-
-}
 
 variable "app_subdomain" {
 

--- a/terraform/stacks/dns/dev.tf
+++ b/terraform/stacks/dns/dev.tf
@@ -1,21 +1,8 @@
 
-resource "aws_route53_zone" "dev_zone" {
-    name = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
-}
-
-resource "aws_route53_record" "dev_ns" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
-  type    = "NS"
-  ttl     = "30"
-  records = aws_route53_zone.dev_zone.name_servers
-}
-
 
 module "dev_dns" {
   source              = "../../modules/environment_dns"
   stack_name          = "development"
-  zone_id             = aws_route53_zone.dev_zone.zone_id
   domain              = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
   app_subdomain       = "app.dev.us-gov-west-1.aws-us-gov.cloud.gov"
   admin_subdomain     = "dev.us-gov-west-1.aws-us-gov.cloud.gov"

--- a/terraform/stacks/dns/production.tf
+++ b/terraform/stacks/dns/production.tf
@@ -1,7 +1,6 @@
 module "production_dns" {
   source              = "../../modules/environment_dns"
   stack_name          = "production"
-  zone_id             = aws_route53_zone.cloud_gov_zone.zone_id
   domain              = "cloud.gov"
   app_subdomain       = "app.cloud.gov"
   admin_subdomain     = "fr.cloud.gov"

--- a/terraform/stacks/dns/staging-tooling.tf
+++ b/terraform/stacks/dns/staging-tooling.tf
@@ -1,6 +1,9 @@
+data "aws_route53_zone" "staging_zone" {
+  name = "fr-stage.cloud.gov"
+}
 
 resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_a" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "prometheus.fr-stage.cloud.gov."
   type    = "A"
 
@@ -12,7 +15,7 @@ resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "prometheus.fr-stage.cloud.gov."
   type    = "AAAA"
 
@@ -24,7 +27,7 @@ resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_aaaa" {
 }
 
 resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_a" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "alertmanager.fr-stage.cloud.gov."
   type    = "A"
 
@@ -36,7 +39,7 @@ resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "alertmanager.fr-stage.cloud.gov."
   type    = "AAAA"
 
@@ -48,7 +51,7 @@ resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_aaaa" {
 }
 
 resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_a" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "grafana.fr-stage.cloud.gov."
   type    = "A"
 
@@ -60,7 +63,7 @@ resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "grafana.fr-stage.cloud.gov."
   type    = "AAAA"
 
@@ -72,7 +75,7 @@ resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_aaaa" {
 }
 
 resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_a" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "doomsday.fr-stage.cloud.gov."
   type    = "A"
 
@@ -84,7 +87,7 @@ resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "doomsday.fr-stage.cloud.gov."
   type    = "AAAA"
 
@@ -96,7 +99,7 @@ resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_aaaa" {
 }
 
 resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_a" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "ci.fr-stage.cloud.gov."
   type    = "A"
 
@@ -108,7 +111,7 @@ resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "ci.fr-stage.cloud.gov."
   type    = "AAAA"
 
@@ -120,7 +123,7 @@ resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_aaaa" {
 }
 
 resource "aws_route53_record" "cloud_gov_credhub-stage_fr_cloud_gov_a" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "credhub.fr-stage.cloud.gov."
   type    = "A"
 
@@ -132,7 +135,7 @@ resource "aws_route53_record" "cloud_gov_credhub-stage_fr_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_credhub-stage_fr_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.staging_zone.zone_id
+  zone_id = data.aws_route53_zone.staging_zone.zone_id
   name    = "credhub.fr-stage.cloud.gov."
   type    = "AAAA"
 

--- a/terraform/stacks/dns/staging.tf
+++ b/terraform/stacks/dns/staging.tf
@@ -1,20 +1,6 @@
-resource "aws_route53_zone" "staging_zone" {
-    name = "fr-stage.cloud.gov"
-}
-
-resource "aws_route53_record" "staging_ns" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "fr-stage.cloud.gov"
-  type    = "NS"
-  ttl     = "30"
-  records = aws_route53_zone.staging_zone.name_servers
-}
-
-
 module "staging_dns" {
   source              = "../../modules/environment_dns"
   stack_name          = "staging"
-  zone_id             = aws_route53_zone.staging_zone.zone_id
   domain              = "fr-stage.cloud.gov"
   app_subdomain       = "app.fr-stage.cloud.gov"
   admin_subdomain     = "fr-stage.cloud.gov"

--- a/terraform/stacks/external/variables.tf
+++ b/terraform/stacks/external/variables.tf
@@ -9,5 +9,16 @@ variable "cdn_broker_hosted_zone" {
 }
 
 
-variable "lets_encrypt_hosted_zone" {
+variable "domain" {
+}
+
+variable "cloud_gov_zone_zone_id" {
+
+}
+
+variable "commercial_assume_arn" {
+
+}
+variable "commercial_aws_default_region" {
+
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- start moving DNS to environments. 

## Context

This is part of decoupling AWS accounts. I'm iterating on getting commercial pieces into their own accounts. 
This is also part of a plan to get each environment into a single Terraform stack. Next up in this plan is:
1.  moving DNS into the main stack
2. move external into main 
3. replace lets encrypt scripts with the lets encrypt terraform module

** after merging this, manual terraform state updates are required **


## security considerations
since this is part of AWS account reorg, it helps us isolate failure and compromise domains, as well as decreasing time to recovery in case of total environment loss