### PR TITLE
Revert "Merge pull request #1790 from cloud-gov/csb-db-name"

### DIFF
--- a/terraform/modules/csb/broker/variables.tf
+++ b/terraform/modules/csb/broker/variables.tf
@@ -30,7 +30,7 @@ variable "rds_db_size" {
 
 variable "rds_db_name" {
   type    = string
-  default = "servicebroker"
+  default = "csb"
 }
 
 variable "rds_db_engine" {


### PR DESCRIPTION
This reverts commit fbd56619f368c0a5bb7fc98205879519cbc32554, reversing changes made to 7803db07dbba55d059ae175df1d4d7a72c32778e.

I figured out how to pass the existing database name to the CSB, so this is no longer necessary.

Related to https://github.com/cloud-gov/product/issues/2989.

## security considerations

None.