### PR TITLE
update default rds engine for defectdojo

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -228,8 +228,8 @@ module "defectdojo_staging" {
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-defectdojo-staging"
-  rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_db_engine_version           = var.rds_db_engine_version_defectdojo_staging
+  rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo
+  rds_db_engine_version           = var.rds_db_engine_version_defectdojo
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -229,7 +229,7 @@ module "defectdojo_staging" {
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-defectdojo-staging"
   rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_db_engine_version           = var.rds_db_engine_version
+  rds_db_engine_version           = var.rds_db_engine_version_defectdojo_staging
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -276,3 +276,7 @@ variable "aws_lb_listener_ssl_policy" {
   type    = string
   default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }
+
+variable "rds_db_engine_version_defectdojo_staging" {
+  default = "16.3"
+}

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -277,6 +277,10 @@ variable "aws_lb_listener_ssl_policy" {
   default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }
 
-variable "rds_db_engine_version_defectdojo_staging" {
+variable "rds_db_engine_version_defectdojo" {
   default = "16.3"
+}
+
+variable "rds_parameter_group_family_defectdojo" {
+  default = "postgres16"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update default db engine to match after updating db version

## security considerations
Fixing terraform to match defectdojo rds version
