### PR TITLE
Logsearch s3 permissions for opensearch

### DIFF
--- a/terraform/modules/iam_role_policy/logs_opensearch_ingestor/policy.json
+++ b/terraform/modules/iam_role_policy/logs_opensearch_ingestor/policy.json
@@ -56,7 +56,7 @@
       "Action": [
            "s3:ListBucket"
       ],
-      "Resource":  "arn:${aws_partition}:s3:::logsearch-*/*"
+      "Resource":  "arn:${aws_partition}:s3:::logsearch-*"
     }
   ]
 }

--- a/terraform/modules/iam_role_policy/logs_opensearch_ingestor/policy.json
+++ b/terraform/modules/iam_role_policy/logs_opensearch_ingestor/policy.json
@@ -43,6 +43,20 @@
       "Resource": [
         "arn:${aws_partition}:logs:${aws_default_region}:${account_id}:log-group:logs-opensearch-*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+           "s3:GetObject"
+      ],
+      "Resource":  "arn:${aws_partition}:s3:::logsearch-*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+           "s3:ListBucket"
+      ],
+      "Resource":  "arn:${aws_partition}:s3:::logsearch-*/*"
     }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- opensearch needs access to s3 for logsearch
-
-

## security considerations
This will be removed when we switch to pulling from opensearch
