### PR TITLE
paramaterize s3 server side encryption

### DIFF
--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encrypted_bucket_
   bucket = aws_s3_bucket.encrypted_bucket.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm = var.server_side_encryption
     }
   }
 }
@@ -60,7 +60,7 @@ resource "aws_s3_bucket_policy" "encrypted_bucket_policy" {
         "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*",
         "Condition": {
             "StringNotEquals": {
-                "s3:x-amz-server-side-encryption": "AES256"
+                "s3:x-amz-server-side-encryption": "${var.server_side_encryption}"
             }
         }
     }]

--- a/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
@@ -19,3 +19,7 @@ variable "aws_partition" {
 variable "expiration_days" {
   default = 0
 }
+
+variable "server_side_encryption" {
+  default = "AES256"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

**Am I having deja vu (https://github.com/cloud-gov/terraform-provision/pull/1796)?**  No. `westa` uses `encrypted_bucket_v2` module while `main` uses `encrypted_bucket`.

This will facilitate conversion of existing S3 platform buckets to use KMS for server side encryption. Because of the default value, this change should not result in any changes to be applied (if it does, something is wrong).

Why not use the kms_encrypted_bucket module? The kms module creates a kms key per bucket. We want to use the same key as it is far more efficient, cheaper, and requires fewer code changes while meeting the FIPS-140 requirements.

## security considerations

Conversion to KMS for server side encryption is required to meet FIPS 140 requirements.
