### PR TITLE
Bosh blobstore kms

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -543,6 +543,7 @@ jobs:
           TF_VAR_domains_lbgroup_count: 2
           TF_VAR_waf_regex_rules: "((development_waf_regex_rules))"
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+          TF_VAR_bosh_blobstore_sse: "aws:kms"
       - *notify-slack
 
   - name: apply-development

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -3,6 +3,7 @@ module "bosh_blobstore_bucket" {
   bucket        = var.blobstore_bucket_name
   aws_partition = data.aws_partition.current.partition
   force_destroy = "true"
+  server_side_encryption = var.bosh_blobstore_sse
 }
 
 module "log_bucket" {

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -1,8 +1,8 @@
 module "bosh_blobstore_bucket" {
-  source        = "../../modules/s3_bucket/encrypted_bucket"
-  bucket        = var.blobstore_bucket_name
-  aws_partition = data.aws_partition.current.partition
-  force_destroy = "true"
+  source                 = "../../modules/s3_bucket/encrypted_bucket"
+  bucket                 = var.blobstore_bucket_name
+  aws_partition          = data.aws_partition.current.partition
+  force_destroy          = "true"
   server_side_encryption = var.bosh_blobstore_sse
 }
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -295,3 +295,7 @@ variable "ecr_stack_name" {
   description = "The name of the stack that configures ECR."
   default     = "ecr"
 }
+
+variable "bosh_blobstore_sse" {
+  default = "AES256"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Uses kms for server side encryption of the bosh blobstore bucket

## security considerations

KMS is required for fips 140 compliance
