### PR TITLE
Add Redis storage for OpenSearch proxy

### DIFF
--- a/terraform/modules/elasticache_replication_group/elasticache.tf
+++ b/terraform/modules/elasticache_replication_group/elasticache.tf
@@ -1,0 +1,17 @@
+resource "aws_elasticache_replication_group" "replication_group" {
+  replication_group_id       = "${var.cluster_name}-cluster"
+  description                = "${var.cluster_name} cluster"
+  node_type                  = var.node_type
+  port                       = 6379
+  auto_minor_version_upgrade = true
+
+  engine             = var.engine
+  engine_version     = var.engine_version
+  num_cache_clusters = var.num_cache_clusters
+
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
+
+  transit_encryption_enabled = true
+  at_rest_encryption_enabled = true
+}

--- a/terraform/modules/elasticache_replication_group/elasticache.tf
+++ b/terraform/modules/elasticache_replication_group/elasticache.tf
@@ -1,9 +1,14 @@
+resource "random_password" "password" {
+  length = 25
+}
+
 resource "aws_elasticache_replication_group" "replication_group" {
   replication_group_id       = "${var.cluster_name}-cluster"
   description                = "${var.cluster_name} cluster"
   node_type                  = var.node_type
   port                       = 6379
   auto_minor_version_upgrade = true
+  auth_token                 = random_password.password.result
 
   engine             = var.engine
   engine_version     = var.engine_version

--- a/terraform/modules/elasticache_replication_group/elasticache.tf
+++ b/terraform/modules/elasticache_replication_group/elasticache.tf
@@ -14,4 +14,7 @@ resource "aws_elasticache_replication_group" "replication_group" {
 
   transit_encryption_enabled = true
   at_rest_encryption_enabled = true
+
+  subnet_group_name  = var.subnet_group_name
+  security_group_ids = var.security_group_ids
 }

--- a/terraform/modules/elasticache_replication_group/outputs.tf
+++ b/terraform/modules/elasticache_replication_group/outputs.tf
@@ -1,0 +1,3 @@
+output "primary_endpoint" {
+  value = aws_elasticache_replication_group.replication_group.primary_endpoint_address
+}

--- a/terraform/modules/elasticache_replication_group/outputs.tf
+++ b/terraform/modules/elasticache_replication_group/outputs.tf
@@ -1,3 +1,8 @@
 output "primary_endpoint" {
   value = aws_elasticache_replication_group.replication_group.primary_endpoint_address
 }
+
+output "password" {
+  value     = random_password.password.result
+  sensitive = true
+}

--- a/terraform/modules/elasticache_replication_group/variables.tf
+++ b/terraform/modules/elasticache_replication_group/variables.tf
@@ -12,15 +12,27 @@ variable "node_type" {
 variable "engine" {
   type        = string
   description = "Engine to use for Elasticache cluster (e.g. redis, valkey)"
+  default     = "redis"
 }
 
 variable "engine_version" {
   type        = string
   description = "Engine version use for Elasticache cluster"
+  default     = "7.1"
 }
 
 variable "num_cache_clusters" {
   type        = number
   description = "Number of cache clusters to use"
   default     = 3
+}
+
+variable "subnet_group_name" {
+  type        = string
+  description = "Name of subnet group to use for Elasticache cluster"
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "List of security group IDs to apply to the Elasticache cluster"
 }

--- a/terraform/modules/elasticache_replication_group/variables.tf
+++ b/terraform/modules/elasticache_replication_group/variables.tf
@@ -1,0 +1,26 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster"
+}
+
+variable "node_type" {
+  type        = string
+  default     = "cache.t3.small"
+  description = "Node type to use for Elasticache cluster"
+}
+
+variable "engine" {
+  type        = string
+  description = "Engine to use for Elasticache cluster (e.g. redis, valkey)"
+}
+
+variable "engine_version" {
+  type        = string
+  description = "Engine version use for Elasticache cluster"
+}
+
+variable "num_cache_clusters" {
+  type        = number
+  description = "Number of cache clusters to use"
+  default     = 3
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -773,3 +773,11 @@ output "csb" {
     }
   }
 }
+
+output "opensearch_proxy_redis_cluster" {
+  value = {
+    host     = module.opensearch_proxy_redis_cluster.primary_endpoint
+    password = module.opensearch_proxy_redis_cluster.password
+  }
+  sensitive = true
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -484,3 +484,11 @@ module "csb_broker" {
   stack_description = var.stack_description
   ecr_stack_name    = var.ecr_stack_name
 }
+
+module "opensearch_proxy_redis_cluster" {
+  source = "../../modules/elasticache_replication_group"
+
+  cluster_name       = "${var.stack_description}-opensearch-proxy"
+  subnet_group_name  = module.elasticache_broker_network.elasticache_subnet_group
+  security_group_ids = [module.elasticache_broker_network.elasticache_redis_security_group]
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/2015

We are switching to backend storage for session data for the OpenSearch Dashboards proxy. This PR adds code to provision an Elasticache Redis instance for each environment of the OpenSearch Dashboards proxy.

## security considerations

No direct security considerations to provisioning these resources. Using Redis for storing session data should be a net benefit for security though.