### PR TITLE
update password for Redis used by OpenSearch proxy

### DIFF
--- a/terraform/modules/elasticache_replication_group/elasticache.tf
+++ b/terraform/modules/elasticache_replication_group/elasticache.tf
@@ -1,5 +1,7 @@
 resource "random_password" "password" {
-  length = 25
+  length = 64
+  # see https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html#auth-overview
+  override_special = "!&#$^<>-"
 }
 
 resource "aws_elasticache_replication_group" "replication_group" {


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/2015

- update password length and allowed special characters for password used by redis for opensearch proxy

## security considerations

Increasing password length is a marginal improvement to security. The changes to the allowed special characters for the password are required to conform to allow characters for passwords in Redis: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html#auth-overview
