### PR TITLE
Adding in NAT GW IPs to SPF

### DIFF
--- a/terraform/stacks/dns/validators.tf
+++ b/terraform/stacks/dns/validators.tf
@@ -20,7 +20,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
   ttl     = 300
 
   records = [
-    "v=spf1 include:mail.zendesk.com include:_spf.google.com ~all",
+    "v=spf1 include:mail.zendesk.com include:_spf.google.com ip4:${data.terraform_remote_state.tooling.outputs.nat_egress_ip_az1} ip4:${data.terraform_remote_state.tooling.outputs.nat_egress_ip_az2} ~all",
     "google-site-verification=jxczK0Pz1ybEFx79BlXIfeX2Cc5vs2YQuqvLnTYF9Bw",
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add to cloud.gov SPF record the AZ1 and AZ2 IPs for Tooling Nat GWs used by postfix

## security considerations
This change allows our SPF record to match so end users don't get a SPF softfail
