### PR TITLE
Adding to SPF record for new Zendesk domain

### DIFF
--- a/terraform/stacks/dns/validators.tf
+++ b/terraform/stacks/dns/validators.tf
@@ -20,7 +20,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
   ttl     = 300
 
   records = [
-    "v=spf1 include:mail.zendesk.com include:_spf.google.com ip4:${data.terraform_remote_state.tooling.outputs.nat_egress_ip_az1} ip4:${data.terraform_remote_state.tooling.outputs.nat_egress_ip_az2} ~all",
+    "v=spf1 include:mail.zendesk.com include:cloud-gov-new.zendesk.com include:_spf.google.com ip4:${data.terraform_remote_state.tooling.outputs.nat_egress_ip_az1} ip4:${data.terraform_remote_state.tooling.outputs.nat_egress_ip_az2} ~all",
     "google-site-verification=jxczK0Pz1ybEFx79BlXIfeX2Cc5vs2YQuqvLnTYF9Bw",
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add to SPF record for `cloud-gov-new.zendesk.com` to prevent emails from being lost to spam

## security considerations
Having updated SPF records help to make sure receipt's email systems trust emails coming from cloud.gov
