### PR TITLE
add logs:DescribeLogGroups permission

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -190,6 +190,15 @@
 
       ],
       "Resource": "*"
-  }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogs"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- add logs:DescribeLogGroups permission which the AWS broker needs to list the current CloudWatch log groups and then associate them to their databases

## security considerations

[`logs:DescribeLogGroups` requires permission to `*` resources](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#:~:text=List-,DescribeLogGroups,-Grants%20permission%20to). This permission is read-only, so not dangerous to add.

