### PR TITLE
fix permission name: DescribeLogs -> DescribeLogGroups

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -194,7 +194,7 @@
     {
       "Effect": "Allow",
       "Action": [
-        "logs:DescribeLogs"
+        "logs:DescribeLogGroups"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix permission name: DescribeLogs -> DescribeLogGroups

## security considerations

see #1811 
