### PR TITLE
Add aws broker tag log groups perm

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -206,7 +206,8 @@
         "logs:TagResource"
       ],
       "Resource": [
-        "arn:${aws_partition}:logs:${aws_default_region}:${account_id}:log-group:/aws/rds/instance/cg-aws-broker*/*"
+        "arn:${aws_partition}:logs:${aws_default_region}:${account_id}:log-group:/aws/rds/instance/cg-aws-broker*/*",
+        "arn:${aws_partition}:logs:${aws_default_region}:${account_id}:log-group:/aws/OpenSearchService/domains/cg-broker*/*"
       ]
     }
   ]

--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -199,6 +199,15 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:TagResource"
+      ],
+      "Resource": [
+        "arn:${aws_partition}:logs:${aws_default_region}:${account_id}:log-group:/aws/rds/instance/cg-aws-broker*/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/144

- Add permissions to allow tagging of cloudwatch log groups associated with brokered resources. This allows us to write a script in the aws-broker that keeps the tags in sync between databases and their log groups (see https://github.com/cloud-gov/aws-broker/pull/397), in turn making sure that logs are ingested with the proper metadata into OpenSearch

## security considerations

We are adding a new permission but TagResource is non-destructive and constrained to a limited set of resources