### PR TITLE
Permit ECR pull users to pull from multiple repositories

### DIFF
--- a/terraform/modules/csb/broker/main.tf
+++ b/terraform/modules/csb/broker/main.tf
@@ -29,12 +29,13 @@ data "terraform_remote_state" "ecr" {
 }
 
 locals {
-  csb_ecr_repository_arn = data.terraform_remote_state.ecr.outputs.repository_arns["csb"]
+  csb_ecr_repository_arn          = data.terraform_remote_state.ecr.outputs.repository_arns["csb"]
+  csb_docproxy_ecr_repository_arn = data.terraform_remote_state.ecr.outputs.repository_arns["csb-docproxy"]
 }
 
 // A user with ECR pull permissions so Cloud Foundry can pull the CSB image.
 module "ecr_user" {
-  source         = "../../iam_user/ecr_pull_user"
-  username       = "csb-ecr-${var.stack_description}"
-  repository_arn = local.csb_ecr_repository_arn
+  source          = "../../iam_user/ecr_pull_user"
+  username        = "csb-ecr-${var.stack_description}"
+  repository_arns = [local.csb_ecr_repository_arn, local.csb_docproxy_ecr_repository_arn]
 }

--- a/terraform/modules/iam_user/ecr_pull_user/policy.tftpl
+++ b/terraform/modules/iam_user/ecr_pull_user/policy.tftpl
@@ -8,7 +8,7 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage"
       ],
-      "Resource": "${repository_arn}"
+      "Resource": ${jsonencode([for arn in repository_arns : "${arn}"])}
     },
     {
       "Effect": "Allow",

--- a/terraform/modules/iam_user/ecr_pull_user/user.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/user.tf
@@ -1,10 +1,3 @@
-data "template_file" "policy" {
-  template = file("${path.module}/policy.json")
-  vars = {
-    "repository_arn" = var.repository_arn
-  }
-}
-
 resource "aws_iam_user" "iam_user" {
   name = var.username
 }
@@ -14,7 +7,10 @@ resource "aws_iam_access_key" "iam_access_key_v3" {
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name   = "${aws_iam_user.iam_user.name}-policy"
-  user   = aws_iam_user.iam_user.name
-  policy = data.template_file.policy.rendered
+  name = "${aws_iam_user.iam_user.name}-policy"
+  user = aws_iam_user.iam_user.name
+
+  policy = templatefile("${path.module}/policy.tftpl", {
+    "repository_arns" = var.repository_arns
+  })
 }

--- a/terraform/modules/iam_user/ecr_pull_user/variables.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/variables.tf
@@ -3,7 +3,7 @@ variable "username" {
   description = "The username of the IAM user."
 }
 
-variable "repository_arn" {
-  type        = string
-  description = "The ARN of the repository in ECR from which the user will pull images."
+variable "repository_arns" {
+  type        = list(string)
+  description = "The ARNs of the repositories in ECR that the user will be permitted to pull from."
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

And grant the CSB user access to its companion repository, csb-docproxy.

Also switch from the templatefile data source to the templatefile function, at the recommendation of the terraform docs. https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file

## security considerations

Expands the permissions of the user that Cloud Foundry uses to pull the CSB-related images.