### PR TITLE
Deprecation of vpc=true

### DIFF
--- a/terraform/modules/bosh_vpc/network_private.tf
+++ b/terraform/modules/bosh_vpc/network_private.tf
@@ -70,14 +70,14 @@ resource "aws_route" "az2_nat_service_route" {
 }
 
 resource "aws_eip" "az1_nat_eip" {
-  vpc = true
+  domain = "vpc"
   lifecycle {
     prevent_destroy = true
   }
 }
 
 resource "aws_eip" "az2_nat_eip" {
-  vpc = true
+  domain = "vpc"
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Receiving the following error:

```
**│ Warning: Argument is deprecated
│ 
│   with module.stack.module.base.module.vpc.aws_eip.az1_nat_eip,
│   on ../../modules/bosh_vpc/network_private.tf line 73, in resource "aws_eip" "az1_nat_eip":
│   73:   vpc = true
│ 
│ use domain attribute instead
│ 
│ (and 3 more similar warnings elsewhere)
```
- Hoping this patches without recreating the resource
- Part of https://github.com/cloud-gov/private/issues/618

## security considerations
Cleaning up deprecated feature in terraform
