### PR TITLE
Rotating cg-rds-storage-alert key

### DIFF
--- a/terraform/modules/iam_user/rds_storage_alert/outputs.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/outputs.tf
@@ -3,9 +3,9 @@ output "username" {
 }
 
 output "access_key_id" {
-  value = aws_iam_access_key.iam_access_key.id
+  value = aws_iam_access_key.iam_access_key_v2.id
 }
 
 output "secret_access_key" {
-  value = aws_iam_access_key.iam_access_key.secret
+  value = aws_iam_access_key.iam_access_key_v2.secret
 }

--- a/terraform/modules/iam_user/rds_storage_alert/user.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/user.tf
@@ -6,7 +6,7 @@ resource "aws_iam_user" "iam_user" {
   name = var.username
 }
 
-resource "aws_iam_access_key" "iam_access_key" {
+resource "aws_iam_access_key" "iam_access_key_v2" {
   user = aws_iam_user.iam_user.name
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- This should rotate the aws access key associated with cg-rds-storage-alert which is consumed by prometheus for alerting
- Part of https://github.com/cloud-gov/private/issues/618
-

## Security considerations

Part of regularly rotating aws iam access keys, assuming this is successful, will update internal docs for future rotations.