### PR TITLE
Deprecation of vpc=true for tooling stack

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -273,7 +273,7 @@ module "monitoring_staging" {
 }
 
 resource "aws_eip" "production_dns_eip" {
-  vpc = true
+  domain = "vpc"
 
   count = var.dns_eip_count_production
 
@@ -283,7 +283,7 @@ resource "aws_eip" "production_dns_eip" {
 }
 
 resource "aws_eip" "staging_dns_eip" {
-  vpc = true
+  domain = "vpc"
 
   count = var.dns_eip_count_staging
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Similar to https://github.com/cloud-gov/terraform-provision/pull/1816, aws_eip is deprecating `vpc = true`, this time for the tooling stack:

```
│ Warning: Argument is deprecated
│ 
│   with aws_eip.production_dns_eip,
│   on stack.tf line 276, in resource "aws_eip" "production_dns_eip":
│  276:   vpc = true
│ 
│ use domain attribute instead
│ 
│ (and 7 more similar warnings elsewhere)
```

- Part of https://github.com/cloud-gov/private/issues/618

## security considerations
Cleaning up deprecated feature in terraform
