### PR TITLE
Allow CSB to send CloudWatch alarms to platform team

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -762,6 +762,10 @@ output "csb" {
       access_key_id_prev     = module.csb_iam.access_key_id_prev
       secret_access_key_prev = module.csb_iam.secret_access_key_prev
     }
+    notification_topics = {
+      email_notification_topic_arn = module.sns.cg_platform_notifications_arn
+      slack_notification_topic_arn = module.sns.cg_platform_slack_notifications_arn
+    }
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

To send alarms, the broker needs access to the notification topics.

Related to https://github.com/cloud-gov/product/issues/3214

## security considerations

The ARNs will not be provided to customers; they will be provided in the CSB at deploy time and, when used by brokered services, configured behind the scenes.