### PR TITLE
Normalize names of cloud service broker related ECR repositories

### DIFF
--- a/terraform/stacks/ecr/variables.tf
+++ b/terraform/stacks/ecr/variables.tf
@@ -15,9 +15,11 @@ variable "repositories" {
     "cloud-service-broker",
     "concourse-http-jq-resource",
     "concourse-task",
+    "cg-csb", # prefixed to avoid collision with the 'csb' pipeline in Concourse.
     "cron-resource",
     "csb",
     "csb-docproxy",
+    "csb-helper",
     "csb-service-updater",
     "email-resource",
     "external-domain-broker-testing",


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/3235

## Changes proposed in this pull request:
- `csb` is renamed to `cg-csb` to avoid pipeline naming conflict with the pipeline that corresponds to the `csb` repo
- `csb-helper` consolidates the docproxy and service updater into one service, and will do other things as well
- Previous repos are preserved until image refs are switched over (future commit in cloud-gov/csb)
- 
## security considerations
None.