### PR TITLE
Ignore all WAF changes due to false positives

### DIFF
--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -18,9 +18,11 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   description = "UAA ELB WAF Rules"
   scope       = "REGIONAL"
 
-  # see https://github.com/hashicorp/terraform-provider-aws/issues/24386#issuecomment-1109340765
+  # Regarding tags_all, see https://github.com/hashicorp/terraform-provider-aws/issues/24386#issuecomment-1109340765
   lifecycle {
-    ignore_changes = [tags_all]
+    # Regarding rule: If you make updates to the WAF rules in this file, you must remove `rule` so they apply.
+    # This is a workaround to an issue: https://github.com/hashicorp/terraform-provider-aws/issues/33124
+    ignore_changes = [rule, tags_all]
   }
 
   default_action {


### PR DESCRIPTION
## Changes proposed in this pull request:

Due to a bug in the provider, terraform detects changes in every rule during every plan and apply. The apply takes ~10 minutes, unnecessarily slowing iteration on the rest of the codebase.

This change works around the issue by ignoring all changes to WAF rules, legitimate or not. To make changes to WAF rules in the future, developers will have to remove 'rule' from this block.

- Related to: https://github.com/hashicorp/terraform-provider-aws/issues/33124
- Slack discussion: https://gsa-tts.slack.com/archives/C0ENP71UG/p1737582745012769

## security considerations
None.