### PR TITLE
Encrypt platform notification SNS topics

### DIFF
--- a/terraform/modules/sns/sns.tf
+++ b/terraform/modules/sns/sns.tf
@@ -1,9 +1,18 @@
+locals {
+  # The alias for the AWS-managed KMS key for SNS.
+  aws_managed_sns_kms_id = "alias/aws/kms"
+}
+
 resource "aws_sns_topic" "cg_platform_notifications" {
   name = var.sns_cg_platform_notifications_name
+
+  kms_master_key_id = local.aws_managed_sns_kms_id
 }
 
 resource "aws_sns_topic" "cg_platform_slack_notifications" {
   name = var.sns_cg_platform_slack_notifications_name
+
+  kms_master_key_id = local.aws_managed_sns_kms_id
 }
 
 resource "aws_sns_topic_subscription" "cg_platform_notifications" {


### PR DESCRIPTION
## Changes proposed in this pull request:

While creating SNS topics for the Cloud Service Broker, Trivy reported that I should encrypt the topics: https://avd.aquasec.com/misconfig/aws/sns/avd-aws-0095

I searched for other topics in our codebase and discovered these were not encrypted. This changes fixes that.

AWS documentation on SNS Server-Side Encryption states that requests must be made with HTTPS and Signature Version 4: https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html This may cause sending to break if we have any client sending without the signature, but I doubt we do; the clients are either AWS services or using the AWS SDK, which handles signing requests.

## security considerations

Improves security. All data should be encrypted at rest when possible. 