### PR TITLE
Explicitly keep previous default for s3 transition lifecycle property

### DIFF
--- a/terraform/modules/external_domain_broker/s3.tf
+++ b/terraform/modules/external_domain_broker/s3.tf
@@ -38,6 +38,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_log_bucket_lifecycl
       days = 930
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 
 resource "aws_s3_bucket_acl" "cloudfront_log_bucket_acl" {

--- a/terraform/modules/log_bucket/log_bucket.tf
+++ b/terraform/modules/log_bucket/log_bucket.tf
@@ -52,6 +52,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
       days = 180
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 resource "aws_s3_bucket_policy" "log_bucket_policy" {
   bucket = aws_s3_bucket.log_bucket.id

--- a/terraform/modules/log_bucket_v2/log_bucket.tf
+++ b/terraform/modules/log_bucket_v2/log_bucket.tf
@@ -50,6 +50,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
       days = 180
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 resource "aws_s3_bucket_policy" "log_bucket_policy" {
   bucket = aws_s3_bucket.log_bucket.id

--- a/terraform/modules/logsearch/platform_log_bucket.tf
+++ b/terraform/modules/logsearch/platform_log_bucket.tf
@@ -19,6 +19,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
       days = 930 # 31 days * 30 months = 930 days
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 
 

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -43,6 +43,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
       }
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 
 resource "aws_s3_bucket_policy" "encrypted_bucket_policy" {

--- a/terraform/modules/s3_bucket/encrypted_bucket_v2/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket_v2/encrypted_bucket.tf
@@ -47,6 +47,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
       }
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 
 resource "aws_s3_bucket_policy" "encrypted_bucket_policy" {

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -77,4 +77,5 @@ resource "aws_s3_bucket_lifecycle_configuration" "kms_encrypted_bucket_lifecycle
       }
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -67,6 +67,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
       }
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 
 resource "aws_s3_bucket_logging" "log_encrypted_bucket_access_logging" {

--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -24,6 +24,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_audit_logs_trail_bucket_lif
       days = 930 # ~30 months for M-21-31 compliance
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }
 
 resource "aws_s3_bucket_logging" "cg-s3-cloudtrail-bucket-logging" {
@@ -134,4 +135,5 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logs_trail_bucket_li
       days = 930 # ~30 months for M-21-31 compliance
     }
   }
+  transition_default_minimum_object_size = "varies_by_storage_class"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

AWS changed the default for this property from varies_by_storage_class to all_storage_classes_128K. For now we are setting this field explicitly so we keep the old behavior.

- The AWS provider has an issue describing this change here: https://github.com/hashicorp/terraform-provider-aws/issues/41126
- AWS docs here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfiguration.html
- Slack thread discussing the change here: https://gsa-tts.slack.com/archives/C0ENP71UG/p1739218411084849

## security considerations

None.