### PR TITLE
Moving pipeline to use GH token from credhub

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1646,7 +1646,7 @@ resources:
     check_every: 1m
     source:
       repository: ((cg_provision_git_repo))
-      access_token: ((status_access_token))
+      access_token: ((status-access-token))
       disable_forks: true
 
   - name: terraform-yaml-tooling


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move GH token for PR check out of s3 file and into credhub for centralized management

## security considerations
Mange GH token lifecycle in credhub prevents duplicate data and split-brain during token rotation
