### PR TITLE
Fix incorrect KMS key alias introduced in 9a53e1b

### DIFF
--- a/terraform/modules/sns/sns.tf
+++ b/terraform/modules/sns/sns.tf
@@ -1,6 +1,6 @@
 locals {
   # The alias for the AWS-managed KMS key for SNS.
-  aws_managed_sns_kms_id = "alias/aws/kms"
+  aws_managed_sns_kms_id = "alias/aws/sns"
 }
 
 resource "aws_sns_topic" "cg_platform_notifications" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- The previous PR used an incorrect alias for the SNS KMS key. 
- Documentation here: https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html#sse-key-terms

## security considerations

None.