### PR TITLE
Add new user for CSB helper

### DIFF
--- a/terraform/modules/csb/iam/govcloud/csb_helper.tf
+++ b/terraform/modules/csb/iam/govcloud/csb_helper.tf
@@ -1,0 +1,37 @@
+data "aws_iam_policy_document" "csb_helper" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ses:UpdateConfigurationSetSendingEnabled"]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:GetTopicAttributes",
+      "sns:Subscribe",
+      "sns:Unsubscribe",
+      "sns:GetSubscriptionAttributes"
+    ]
+    resources = [var.sns_platform_notification_topic_arn]
+  }
+}
+
+resource "aws_iam_policy" "csb_helper" {
+  name        = "${var.stack_description}-csb-helper"
+  description = "Policy for the CSB Helper web service, which supports the Cloud Service Broker."
+  policy      = data.aws_iam_policy_document.csb_helper.json
+}
+
+resource "aws_iam_user" "csb_helper" {
+  name = "${var.stack_description}-csb-helper"
+}
+
+resource "aws_iam_access_key" "csb_helper" {
+  user = aws_iam_user.csb_helper.name
+}
+
+resource "aws_iam_user_policy_attachment" "csb_helper" {
+  user       = aws_iam_user.csb_helper.name
+  policy_arn = aws_iam_user.csb_helper.name
+}

--- a/terraform/modules/csb/iam/govcloud/outputs.tf
+++ b/terraform/modules/csb/iam/govcloud/outputs.tf
@@ -17,6 +17,25 @@ output "csb_secret_access_key_curr" {
   sensitive = true
 }
 
+// CSB Helper
+output "csb_helper_access_key_id_prev" {
+  value = ""
+}
+
+output "csb_helper_secret_access_key_prev" {
+  value     = ""
+  sensitive = true
+}
+
+output "csb_helper_access_key_id_curr" {
+  value = aws_iam_access_key.csb_helper.id
+}
+
+output "csb_helper_secret_access_key_curr" {
+  value     = aws_iam_access_key.csb_helper.secret
+  sensitive = true
+}
+
 // Concourse
 output "concourse_access_key_id_prev" {
   value = ""

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -739,6 +739,12 @@ output "csb" {
         access_key_id_prev     = module.csb_iam.csb_access_key_id_prev
         secret_access_key_prev = module.csb_iam.csb_secret_access_key_prev
       }
+      csb_helper = {
+        access_key_id_curr     = module.csb_iam.csb_helper_access_key_id_curr
+        secret_access_key_curr = module.csb_iam.csb_helper_secret_access_key_curr
+        access_key_id_prev     = module.csb_iam.csb_helper_access_key_id_prev
+        secret_access_key_prev = module.csb_iam.csb_helper_secret_access_key_prev
+      }
       concourse = {
         access_key_id_curr     = module.csb_iam.concourse_access_key_id_curr
         secret_access_key_curr = module.csb_iam.concourse_secret_access_key_curr


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add new user for CSB Helper so it can pause sending on SES identities
- Related to https://github.com/cloud-gov/product/issues/3214

## security considerations

None. Observes standard Terraform security practices.