### PR TITLE
Switch domain-broker db to use pg 15.7

### DIFF
--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -124,7 +124,7 @@ variable "parent_stack_name" {
 }
 
 variable "domains_broker_rds_version" {
-  default = "12.19"
+  default = "15.7"
 }
 variable "cf_rds_instance_type" {
   default = "db.m5.large"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bumps the version of RDS Postgres from 12.9 to 15.7, starting with dev
- Identified as 3 of the dbs needing upgrades controlled by ops
- Part of platform maintenance: https://github.com/cloud-gov/private/issues/618
-

## security considerations
Bumps to a newer version of Postgres, no code changes to the domain broker itself
