### PR TITLE
Fully revert attempt at scoping down resource access

### DIFF
--- a/terraform/modules/csb/iam/govcloud/csb.tf
+++ b/terraform/modules/csb/iam/govcloud/csb.tf
@@ -1,22 +1,12 @@
 // See also the companion user in Commercial (../commercial/csb.tf)
 // Originally from https://github.com/GSA-TTS/datagov-brokerpak-smtp/blob/main/permission-policies.tf
 
-data "aws_caller_identity" "current" {}
-data "aws_partition" "current" {}
-
-locals {
-  arn_template   = "arn:${data.aws_partition.current.partition}:%s::${data.aws_caller_identity.current.account_id}:csb-aws-ses-*"
-  ses_arn        = format(local.arn_template, "ses")
-  iam_arn        = format(local.arn_template, "iam")
-  sns_arn        = format(local.arn_template, "sns")
-  cloudwatch_arn = format(local.arn_template, "cloudwatch")
-}
 
 data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
   statement {
     effect    = "Allow"
     actions   = ["ses:*"]
-    resources = [local.ses_arn]
+    resources = ["*"]
   }
 
   statement {
@@ -37,7 +27,7 @@ data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
       "iam:DetachUserPolicy",
       "iam:List*"
     ]
-    resources = [local.iam_arn]
+    resources = ["*"]
   }
 
   statement {
@@ -52,7 +42,7 @@ data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
       "sns:Unsubscribe",
       "sns:GetSubscriptionAttributes"
     ]
-    resources = [local.sns_arn]
+    resources = ["*"]
   }
 
   statement {
@@ -60,7 +50,7 @@ data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
     actions = [
       "cloudwatch:PutMetricAlarm",
     ]
-    resources = [local.cloudwatch_arn]
+    resources = ["*"]
   }
 
 }
@@ -80,6 +70,8 @@ resource "aws_iam_access_key" "csb" {
 }
 
 // Values required for policy attachment
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 locals {
   this_aws_account_id = data.aws_caller_identity.current.account_id
   // Attribute aws_iam_policy.brokerpak_aws_ses.arn is not determined until apply, so it cannot be


### PR DESCRIPTION

## Changes proposed in this pull request:

The terraform apply fails with an error about the resource name, so at this point I don't think there's any point in using an ARN at all. Just granting on all resources instead.

## security considerations
Outlined need for this permission set above.