### PR TITLE
Add additional permissions required for CSB to manage metric alarms

### DIFF
--- a/terraform/modules/csb/iam/govcloud/csb.tf
+++ b/terraform/modules/csb/iam/govcloud/csb.tf
@@ -48,7 +48,13 @@ data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
   statement {
     effect = "Allow"
     actions = [
+      "cloudwatch:DeleteAlarms",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:DisableAlarmActions",
+      "cloudwatch:EnableAlarmActions",
+      "cloudwatch:ListTagsForResource",
       "cloudwatch:PutMetricAlarm",
+      "cloudwatch:SetAlarmState",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Ongoing work related to https://github.com/cloud-gov/product/issues/3214

## security considerations
Adds permissions to CSB user, required to deploy brokered SES.