### PR TITLE
Configure autoscaler db version from pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -508,6 +508,8 @@ jobs:
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
+          TF_VAR_rds_db_engine_version_autoscaler: "15.7"
+          TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_restricted_ingress_web_cidrs: ((development_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((development_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.dev.us-gov-west-1.aws-us-gov.cloud.gov
@@ -680,6 +682,8 @@ jobs:
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
+          TF_VAR_rds_db_engine_version_autoscaler: "15.7"
+          TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
           TF_VAR_cf_rds_password: ((staging_cf_rds_password))
@@ -850,6 +854,8 @@ jobs:
           TF_VAR_credhub_rds_password: ((production_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
+          TF_VAR_rds_db_engine_version_autoscaler: "15.7"
+          TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -315,6 +315,8 @@ module "autoscaler" {
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
   rds_instance_type               = var.cf_as_rds_instance_type
+  rds_parameter_group_family      = var.rds_db_engine_version_autoscaler
+  rds_db_engine_version           = var.rds_parameter_group_family_autoscaler
 
 }
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -32,6 +32,14 @@ variable "rds_parameter_group_family" {
   default = "postgres12"
 }
 
+variable "rds_db_engine_version_autoscaler" {
+  default = "15.7"
+}
+
+variable "rds_parameter_group_family_autoscaler" {
+  default = "postgres15"
+}
+
 variable "rds_db_engine_version_cf" {
   default = "16.3"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- This should allow the version of the autoscaler database to be controlled from the pipeline instead of relying only on the module defaults, meaning that development, staging and production can be rolled out separately without having to put all other changes to terraform-provision on hold.  A second PR will make the attempt at the upgrade to 15.12. Nifty, right?
- Part of https://github.com/cloud-gov/private/issues/2364 
-

## security considerations
Should be a no-op change
