### PR TITLE
set up stack to use only prod, and rotate check-limit-user

### DIFF
--- a/terraform/modules/iam_user/limit_check_user/outputs.tf
+++ b/terraform/modules/iam_user/limit_check_user/outputs.tf
@@ -3,17 +3,17 @@ output "username" {
 }
 
 output "access_key_id_prev" {
-  value = ""
-}
-
-output "secret_access_key_prev" {
-  value = ""
-}
-
-output "access_key_id_curr" {
   value = aws_iam_access_key.iam_access_key_v3.id
 }
 
-output "secret_access_key_curr" {
+output "secret_access_key_prev" {
   value = aws_iam_access_key.iam_access_key_v3.secret
+}
+
+output "access_key_id_curr" {
+  value = aws_iam_access_key.iam_access_key_v4.id
+}
+
+output "secret_access_key_curr" {
+  value = aws_iam_access_key.iam_access_key_v4.secret
 }

--- a/terraform/modules/iam_user/limit_check_user/user.tf
+++ b/terraform/modules/iam_user/limit_check_user/user.tf
@@ -10,6 +10,10 @@ resource "aws_iam_access_key" "iam_access_key_v3" {
   user = aws_iam_user.iam_user.name
 }
 
+resource "aws_iam_access_key" "iam_access_key_v4" {
+  user = aws_iam_user.iam_user.name
+}
+
 resource "aws_iam_user_policy" "iam_policy" {
   name   = "${aws_iam_user.iam_user.name}-policy"
   user   = aws_iam_user.iam_user.name

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -96,24 +96,24 @@ output "cdn_broker_secret_access_key_curr" {
 
 /* limit check user */
 output "limit_check_username" {
-  value = join("", module.limit_check_user.username)
+  value = join("", module.limit_check_user.*.username)
 }
 
 output "limit_check_access_key_id_prev" {
-  value = join("", module.limit_check_user.access_key_id_prev)
+  value = join("", module.limit_check_user.*.access_key_id_prev)
 }
 
 output "limit_check_secret_access_key_prev" {
-  value     = join("", module.limit_check_user.secret_access_key_prev)
+  value     = join("", module.limit_check_user.*.secret_access_key_prev)
   sensitive = true
 }
 
 output "limit_check_access_key_id_curr" {
-  value = join("", module.limit_check_user.access_key_id_curr)
+  value = join("", module.limit_check_user.*.access_key_id_curr)
 }
 
 output "limit_check_secret_access_key_curr" {
-  value     = join("", module.limit_check_user.secret_access_key_curr)
+  value     = join("", module.limit_check_user.*.secret_access_key_curr)
   sensitive = true
 }
 

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -96,24 +96,24 @@ output "cdn_broker_secret_access_key_curr" {
 
 /* limit check user */
 output "limit_check_username" {
-  value = module.limit_check_user.username
+  value = join("", module.limit_check_user.username)
 }
 
 output "limit_check_access_key_id_prev" {
-  value = module.limit_check_user.access_key_id_prev
+  value = join("", module.limit_check_user.access_key_id_prev)
 }
 
 output "limit_check_secret_access_key_prev" {
-  value     = module.limit_check_user.secret_access_key_prev
+  value     = join("", module.limit_check_user.secret_access_key_prev)
   sensitive = true
 }
 
 output "limit_check_access_key_id_curr" {
-  value = module.limit_check_user.access_key_id_curr
+  value = join("", module.limit_check_user.access_key_id_curr)
 }
 
 output "limit_check_secret_access_key_curr" {
-  value     = module.limit_check_user.secret_access_key_curr
+  value     = join("", module.limit_check_user.secret_access_key_curr)
   sensitive = true
 }
 

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -72,6 +72,7 @@ module "cdn_broker" {
 }
 
 module "limit_check_user" {
+  count    = var.stack_description == "production" ? 1 : 0
   source   = "../../modules/iam_user/limit_check_user"
   username = "limit-check-${var.stack_description}"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Side effect will be to delete both dev and staging
- Only one user type is used, so keeping prod and getting rid of the rest


## security considerations
None