### PR TITLE
Work around inconsistency with staging domain

### DIFF
--- a/terraform/modules/environment_dns/dns.tf
+++ b/terraform/modules/environment_dns/dns.tf
@@ -224,10 +224,12 @@ resource "aws_route53_record" "brokered_mail_ns" {
 }
 
 locals {
+  # Work around the staging apex domain being inconsistent with the rest.
+  external_domain_suffix        = trimprefix(var.domain, "fr-stage.")
   csb_helper_domain_name        = "services.${var.domain}."
-  csb_helper_domain_record      = "services.${var.domain}.external-domains-${var.stack_name}.${var.domain}."
+  csb_helper_domain_record      = "services.${var.domain}.external-domains-${var.stack_name}.${local.external_domain_suffix}."
   csb_helper_acme_domain_name   = "_acme-challenge.services.${var.domain}."
-  csb_helper_acme_domain_record = "_acme-challenge.services.${var.domain}.external-domains-${var.stack_name}.${var.domain}."
+  csb_helper_acme_domain_record = "_acme-challenge.services.${var.domain}.external-domains-${var.stack_name}.${local.external_domain_suffix}."
 }
 
 // DNS records corresponding to the External Domain Service Instance


### PR DESCRIPTION
## Changes proposed in this pull request:

The staging domain as it is defined here is the subdomain starting with `fr-stage.`, but the external domain broker is deployed directly to the parent domain. In all other environments, the previous code worked fine, and this fix will not affect them.

## security considerations
None