### PR TITLE
Update autoscaler dbs to 15.12

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -508,7 +508,7 @@ jobs:
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
-          TF_VAR_rds_db_engine_version_autoscaler: "15.7"
+          TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_restricted_ingress_web_cidrs: ((development_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((development_restricted_ingress_web_ipv6_cidrs))
@@ -682,7 +682,7 @@ jobs:
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
-          TF_VAR_rds_db_engine_version_autoscaler: "15.7"
+          TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
@@ -854,7 +854,7 @@ jobs:
           TF_VAR_credhub_rds_password: ((production_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
-          TF_VAR_rds_db_engine_version_autoscaler: "15.7"
+          TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))


### PR DESCRIPTION
## Changes proposed in this pull request:
- This makes what is currently deployed match with the pipeline.yml definition, the upgrades were done via aws console and running the acceptance tests afterwards
- Part of https://github.com/cloud-gov/private/issues/2364 
-

## security considerations
This results in a no-op change

