### PR TITLE
Autoscaler enforce ssl in parameter group

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -510,6 +510,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
+          TF_VAR_rds_force_ssl_autoscaler: 0
           TF_VAR_restricted_ingress_web_cidrs: ((development_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((development_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.dev.us-gov-west-1.aws-us-gov.cloud.gov
@@ -684,6 +685,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
+          TF_VAR_rds_force_ssl_autoscaler: 0
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
           TF_VAR_cf_rds_password: ((staging_cf_rds_password))
@@ -856,6 +858,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
+          TF_VAR_rds_force_ssl_autoscaler: 0
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -510,7 +510,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-          TF_VAR_rds_force_ssl_autoscaler: 0
+          TF_VAR_rds_force_ssl_autoscaler: 1
           TF_VAR_restricted_ingress_web_cidrs: ((development_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((development_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.dev.us-gov-west-1.aws-us-gov.cloud.gov

--- a/terraform/modules/autoscaler/database.tf
+++ b/terraform/modules/autoscaler/database.tf
@@ -14,4 +14,5 @@ module "cf_as_database" {
   rds_parameter_group_family      = var.rds_parameter_group_family
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
+  rds_force_ssl                   = var.rds_force_ssl
 }

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -47,3 +47,7 @@ variable "rds_apply_immediately" {
 variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
+
+variable "rds_force_ssl" {
+  default = 1
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -317,6 +317,7 @@ module "autoscaler" {
   rds_instance_type               = var.cf_as_rds_instance_type
   rds_db_engine_version           = var.rds_db_engine_version_autoscaler
   rds_parameter_group_family      = var.rds_parameter_group_family_autoscaler
+  rds_force_ssl                   = var.rds_force_ssl_autoscaler
 
 }
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -40,6 +40,10 @@ variable "rds_parameter_group_family_autoscaler" {
   default = "postgres15"
 }
 
+variable "rds_force_ssl_autoscaler" {
+  default = 1
+}
+
 variable "rds_db_engine_version_cf" {
   default = "16.3"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- This change will modify the parameter group for the autoscaler RDS instance to require ssl to be enabled, the value is being added in TF_VAR_ in dev/stage/prod to control the rollout without blocking others with changes.  Dev is set to 1, the other environments are 0 which is the current original default of the rds module.
- Tested in dev manually by setting the value in the custom `autoscaler-development` parameter group and running the acceptance tests.
- Part of https://github.com/cloud-gov/private/issues/2364 

## security considerations
Finally circling back to this, while all the db connections were using SSL, this setting in the parameter group will prevent any non-SSL connections.
