### PR TITLE
Autoscaler enforce ssl in parameter group (staging and production)

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -685,7 +685,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-          TF_VAR_rds_force_ssl_autoscaler: 0
+          TF_VAR_rds_force_ssl_autoscaler: 1
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
           TF_VAR_cf_rds_password: ((staging_cf_rds_password))
@@ -858,7 +858,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-          TF_VAR_rds_force_ssl_autoscaler: 0
+          TF_VAR_rds_force_ssl_autoscaler: 1
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))


### PR DESCRIPTION
## Changes proposed in this pull request:
- This change will modify the parameter group for the autoscaler RDS instance to require ssl to be enabled, the value is being added in TF_VAR_ in dev/stage/prod to control the rollout without blocking others with changes.  Dev was set with https://github.com/cloud-gov/terraform-provision/pull/1850 , this PR does the same for staging and production
- Part of https://github.com/cloud-gov/private/issues/2364 

## security considerations
Finally circling back to this, while all the db connections were using SSL, this setting in the parameter group will prevent any non-SSL connections for staging and development.
