### PR TITLE
Enforce ssl in parameter group for RDS BOSH dbs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -391,6 +391,7 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
           TF_VAR_rds_db_engine_version_bosh: "15.7"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
+          TF_VAR_rds_force_ssl_bosh: 0
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_credhub_staging: "15.7"
@@ -501,6 +502,7 @@ jobs:
           TF_VAR_vpc_cidr: ((development_vpc_cidr))
           TF_VAR_rds_db_engine_version: "15.7"
           TF_VAR_rds_parameter_group_family: "postgres15"
+          TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_db_engine_version_cf: "16.3"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_cf_rds_password: ((development_cf_rds_password))
@@ -678,6 +680,7 @@ jobs:
           #TF_VAR_rds_allow_major_version_upgrade: "true"
           TF_VAR_rds_db_engine_version: "15.7"
           TF_VAR_rds_parameter_group_family: "postgres15"
+          TF_VAR_rds_force_ssl: 0
           TF_VAR_rds_db_engine_version_cf: "16.3"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
@@ -848,6 +851,7 @@ jobs:
           # IDs from `data` resources.
           TF_VAR_rds_db_engine_version: "15.7"
           TF_VAR_rds_parameter_group_family: "postgres15"
+          TF_VAR_rds_force_ssl: 0
           TF_VAR_rds_password: ((production_rds_password))
           TF_VAR_rds_db_size: ((production_rds_db_size))
           # Enable for database upgrades:

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -55,6 +55,7 @@ module "rds" {
   rds_subnet_group                = module.rds_network.rds_subnet_group
   rds_security_groups             = [module.rds_network.rds_postgres_security_group]
   rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_force_ssl                   = var.rds_force_ssl
 }
 
 module "credhub_rds" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -172,6 +172,10 @@ variable "rds_parameter_group_name" {
   default = ""
 }
 
+variable "rds_force_ssl" {
+  default = 1
+}
+
 variable "credhub_rds_force_ssl" {
   default = 1
 }

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -20,6 +20,7 @@ module "base" {
   rds_db_engine                      = var.rds_db_engine
   rds_db_engine_version              = var.rds_db_engine_version
   rds_parameter_group_family         = var.rds_parameter_group_family
+  rds_force_ssl                      = var.rds_force_ssl
   rds_allow_major_version_upgrade    = var.rds_allow_major_version_upgrade
   rds_apply_immediately              = var.rds_apply_immediately
   rds_username                       = var.rds_username

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -83,6 +83,10 @@ variable "rds_username" {
   default = "bosh"
 }
 
+variable "rds_force_ssl" {
+  default = 1
+}
+
 variable "restricted_ingress_web_cidrs" {
   type    = list(string)
   default = ["127.0.0.1/32", "192.168.0.1/24"]

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -195,6 +195,7 @@ module "stack" {
   rds_instance_type                       = var.rds_instance_type
   rds_db_engine_version                   = var.rds_db_engine_version
   rds_parameter_group_family              = var.rds_parameter_group_family
+  rds_force_ssl                           = var.rds_force_ssl
   public_cidr_1                           = cidrsubnet(var.vpc_cidr, 8, 100)
   public_cidr_2                           = cidrsubnet(var.vpc_cidr, 8, 101)
   private_cidr_1                          = cidrsubnet(var.vpc_cidr, 8, 1)

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -32,6 +32,10 @@ variable "rds_parameter_group_family" {
   default = "postgres12"
 }
 
+variable "rds_force_ssl" {
+  default = 1
+}
+
 variable "rds_db_engine_version_autoscaler" {
   default = "15.7"
 }

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -98,6 +98,7 @@ module "stack" {
   rds_security_groups_count              = "1"
   rds_db_engine_version                  = var.rds_db_engine_version_bosh
   rds_parameter_group_family             = var.rds_parameter_group_family_bosh
+  rds_force_ssl                          = var.rds_force_ssl_bosh
   rds_allow_major_version_upgrade        = var.rds_allow_major_version_upgrade
   rds_apply_immediately                  = var.rds_apply_immediately
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -45,6 +45,10 @@ variable "rds_parameter_group_family_bosh" {
   default = "postgres15"
 }
 
+variable "rds_force_ssl_bosh" {
+  default = 1
+}
+
 variable "rds_db_engine_version_credhub_staging" {
   default = "15.5"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- This change will modify the parameter group for the bosh RDS instance to require ssl to be enabled, the value is being added in TF_VAR_ in dev/stage/prod/tooling to control the rollout without blocking others with changes.  Dev is set to 1, the other environments are 0 which is the current original default of the rds module.
- Tested in dev manually by setting the value in the custom `development-bosh` parameter group and logging into the bosh director and displaying deployments
- Part of https://github.com/cloud-gov/private/issues/2386

## security considerations
Finally circling back to this, while all the db connections were using SSL, this setting in the parameter group will prevent any non-SSL connections.
