### PR TITLE
revert changes to make rds.force_ssl dynamic

### DIFF
--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -28,13 +28,10 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
     value = "ddl"
   }
 
-  dynamic "parameter" {
-    for_each = contains(["postgres15", "postgres16"], var.rds_parameter_group_family) ? [] : [1]
-    content {
-      name         = "rds.force_ssl"
-      value        = var.rds_force_ssl
-      apply_method = "pending-reboot"
-    }
+  parameter {
+    name         = "rds.force_ssl"
+    value        = var.rds_force_ssl
+    apply_method = "pending-reboot"    
   }
 }
 

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -31,7 +31,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
   parameter {
     name         = "rds.force_ssl"
     value        = var.rds_force_ssl
-    apply_method = "pending-reboot"    
+    apply_method = "pending-reboot"
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Reverts #1863 

## security considerations

None, we're just trying to preserve existing behavior of parameter groups
