### PR TITLE
Refactor static IP outputs to deprecate use of template_file

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -149,12 +149,12 @@ output "services_subnet_reserved_az2" {
 /* Per-deployment static IP ranges */
 /* TODO: Make this go away */
 output "logsearch_static_ips" {
-  value = [for i in range(0, 30) : cidrhost(module.cf.services_cidr_1, i + 20)]
+  value = [for i in range(0, 31) : cidrhost(module.cf.services_cidr_1, i + 20)]
 }
 
 output "services_static_ips" {
   value = concat(
-    [for i in range(0, 30) : cidrhost(module.cf.services_cidr_1, i + 20)],
+    [for i in range(0, 31) : cidrhost(module.cf.services_cidr_1, i + 20)],
   )
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -149,12 +149,12 @@ output "services_subnet_reserved_az2" {
 /* Per-deployment static IP ranges */
 /* TODO: Make this go away */
 output "logsearch_static_ips" {
-  value = [for i in range : cidrhost(module.cf.services_cidr_1, i + 20)]
+  value = [for i in range(0, 30) : cidrhost(module.cf.services_cidr_1, i + 20)]
 }
 
 output "services_static_ips" {
   value = concat(
-    [for i in range : cidrhost(module.cf.services_cidr_1, i + 20)],
+    [for i in range(0, 30) : cidrhost(module.cf.services_cidr_1, i + 20)],
   )
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -149,12 +149,12 @@ output "services_subnet_reserved_az2" {
 /* Per-deployment static IP ranges */
 /* TODO: Make this go away */
 output "logsearch_static_ips" {
-  value = [for i in range: cidrhost(module.cf.services_cidr_1, count.index + 20)]
+  value = [for i in range: cidrhost(module.cf.services_cidr_1, i + 20)]
 }
 
 output "services_static_ips" {
   value = concat(
-    [for i in range: cidrhost(module.cf.services_cidr_1, count.index + 20)],
+    [for i in range: cidrhost(module.cf.services_cidr_1, i + 20)],
   )
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -148,21 +148,13 @@ output "services_subnet_reserved_az2" {
 
 /* Per-deployment static IP ranges */
 /* TODO: Make this go away */
-data "template_file" "logsearch_static_ips" {
-  count = 31
-  vars = {
-    address = cidrhost(module.cf.services_cidr_1, count.index + 20)
-  }
-  template = "$${address}"
-}
-
 output "logsearch_static_ips" {
-  value = data.template_file.logsearch_static_ips.*.rendered
+  value = [for i in range: cidrhost(module.cf.services_cidr_1, count.index + 20)]
 }
 
 output "services_static_ips" {
   value = concat(
-    data.template_file.logsearch_static_ips.*.rendered,
+    [for i in range: cidrhost(module.cf.services_cidr_1, count.index + 20)],
   )
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -149,12 +149,12 @@ output "services_subnet_reserved_az2" {
 /* Per-deployment static IP ranges */
 /* TODO: Make this go away */
 output "logsearch_static_ips" {
-  value = [for i in range: cidrhost(module.cf.services_cidr_1, i + 20)]
+  value = [for i in range : cidrhost(module.cf.services_cidr_1, i + 20)]
 }
 
 output "services_static_ips" {
   value = concat(
-    [for i in range: cidrhost(module.cf.services_cidr_1, i + 20)],
+    [for i in range : cidrhost(module.cf.services_cidr_1, i + 20)],
   )
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Follow-up to #1862. Deprecating further since [usage of `template_file` since it is deprecated](https://github.com/hashicorp/terraform-provider-template/issues/85).

## security considerations

None. There are no material changes to the output of the TF code, we are just refactoring the source code to produce the same output using different TF functions.
