### PR TITLE
Create the CSB database in production

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -751,13 +751,12 @@ output "csb" {
       }
     }
     rds = {
-      # Use one() because broker module count is used to only create the module in dev. Once deployed in all environments and count is removed, this can be simplified.
-      host     = one(module.csb_broker[*].rds_host)
-      port     = one(module.csb_broker[*].rds_port)
-      url      = one(module.csb_broker[*].rds_url)
-      name     = one(module.csb_broker[*].rds_name)
-      username = one(module.csb_broker[*].rds_username)
-      password = one(module.csb_broker[*].rds_password)
+      host     = module.csb_broker.rds_host
+      port     = module.csb_broker.rds_port
+      url      = module.csb_broker.rds_url
+      name     = module.csb_broker.rds_name
+      username = module.csb_broker.rds_username
+      password = module.csb_broker.rds_password
     }
     notification_topics = {
       email_notification_topic_arn = module.sns.cg_platform_notifications_arn

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -465,8 +465,6 @@ resource "random_password" "csb_rds_password" {
 }
 
 module "csb_broker" {
-  count = var.stack_description == "production" ? 0 : 1
-
   source            = "../../modules/csb/broker"
   stack_description = var.stack_description
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Prepare for SCR and beta by deploying database to production
- Related to https://github.com/cloud-gov/product/issues/3043
- The broker will not yet be enabled; changes [here](https://github.com/cloud-gov/csb/commit/9bef7e6deb5c9b5f0a88df455f6562c77df8dff6) and later commits make the broker unroutable

## security considerations

Uses our standard procedure for creating new platform-level databases.
