### PR TITLE
Renable force ssl for tooling/prod now that toolbelt replaced

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -397,7 +397,7 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
-          TF_VAR_rds_force_ssl_bosh: 0
+          TF_VAR_rds_force_ssl_bosh: 1
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_credhub_staging: "15.7"
@@ -857,7 +857,7 @@ jobs:
           # IDs from `data` resources.
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
-          TF_VAR_rds_force_ssl: 0
+          TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_password: ((production_rds_password))
           TF_VAR_rds_db_size: ((production_rds_db_size))
           # Enable for database upgrades:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Forces ssl on RDS databases for tooling and production bosh
- This was originally blocked by https://github.com/cloud-gov/deploy-bosh/pull/637 but is now resolved
- The change was already done via AWS Console, this should result in a no-op
- Part of https://github.com/cloud-gov/private/issues/2386 and https://github.com/cloud-gov/private/issues/2387

## security considerations
This enforces SSL to RDS
