### PR TITLE
Concourse & Concourse credhub staging/production to 15.12

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -395,21 +395,33 @@ jobs:
           TF_VAR_defectdojo_staging_hosts: '["defectdojo.fr-stage.cloud.gov"]'
           TF_VAR_defectdojo_staging_oidc_client: ((tooling_defectdojo_staging_oidc_client))
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
+
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
           TF_VAR_rds_force_ssl_bosh: 1
+
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
-          TF_VAR_rds_db_engine_version_credhub_staging: "15.7"
+
+          TF_VAR_rds_db_engine_version_credhub_staging: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
-          TF_VAR_rds_db_engine_version_credhub_production: "15.7"
+          TF_VAR_rds_force_ssl_credhub_staging: 1
+          
+          TF_VAR_rds_db_engine_version_credhub_production: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
-          TF_VAR_rds_db_engine_version_concourse_staging: "15.7"
+          TF_VAR_rds_force_ssl_credhub_production: 1
+
+          TF_VAR_rds_db_engine_version_concourse_staging: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
-          TF_VAR_rds_db_engine_version_concourse_production: "15.7"
+          TF_VAR_rds_force_ssl_concourse_staging: 1
+
+          TF_VAR_rds_db_engine_version_concourse_production: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
+          TF_VAR_rds_force_ssl_concourse_production: 1
+
           TF_VAR_rds_db_engine_version_opsuaa: "16.3"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
+          
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
 

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -19,4 +19,5 @@ module "rds_96" {
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
   performance_insights_enabled    = var.performance_insights_enabled
+  rds_force_ssl                   = var.rds_force_ssl 
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -88,3 +88,7 @@ variable "hosts" {
 variable "performance_insights_enabled" {
   default = "false"
 }
+
+variable "rds_force_ssl" {
+  default = 1
+}

--- a/terraform/modules/credhub/rds.tf
+++ b/terraform/modules/credhub/rds.tf
@@ -18,4 +18,5 @@ module "rds_96" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
+  rds_force_ssl                   = var.rds_force_ssl
 }

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -92,3 +92,7 @@ variable "listener_arn" {
 variable "hosts" {
   type = list(string)
 }
+
+variable "rds_force_ssl" {
+  default = 1
+}

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -124,6 +124,7 @@ module "concourse_production" {
   rds_parameter_group_family      = var.rds_parameter_group_family_concourse_production
   rds_db_engine_version           = var.rds_db_engine_version_concourse_production
   rds_apply_immediately           = var.rds_apply_immediately
+  rds_force_ssl                   = var.rds_force_ssl_concourse_production
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   performance_insights_enabled    = "true"
   rds_instance_type               = "db.m5.4xlarge"
@@ -151,6 +152,7 @@ module "concourse_staging" {
   rds_parameter_group_family      = var.rds_parameter_group_family_concourse_staging
   rds_db_engine_version           = var.rds_db_engine_version_concourse_staging
   rds_apply_immediately           = var.rds_apply_immediately
+  rds_force_ssl                   = var.rds_force_ssl_concourse_staging
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
   rds_db_size                     = 400
@@ -179,6 +181,7 @@ module "credhub_production" {
   rds_parameter_group_family      = var.rds_parameter_group_family_credhub_production
   rds_db_engine_version           = var.rds_db_engine_version_credhub_production
   rds_apply_immediately           = var.rds_apply_immediately
+  rds_force_ssl                   = var.rds_force_ssl_credhub_production
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
   rds_multi_az                    = var.rds_multi_az
@@ -204,6 +207,7 @@ module "credhub_staging" {
   rds_parameter_group_family      = var.rds_parameter_group_family_credhub_staging
   rds_db_engine_version           = var.rds_db_engine_version_credhub_staging
   rds_apply_immediately           = var.rds_apply_immediately
+  rds_force_ssl                   = var.rds_force_ssl_credhub_staging
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
   rds_db_size                     = 400

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -57,12 +57,20 @@ variable "rds_parameter_group_family_credhub_staging" {
   default = "postgres15"
 }
 
+variable "rds_force_ssl_credhub_staging" {
+  default = 1
+}
+
 variable "rds_db_engine_version_credhub_production" {
   default = "15.5"
 }
 
 variable "rds_parameter_group_family_credhub_production" {
   default = "postgres15"
+}
+
+variable "rds_force_ssl_credhub_production" {
+  default = 1
 }
 
 variable "rds_db_engine_version_concourse_staging" {
@@ -73,12 +81,20 @@ variable "rds_parameter_group_family_concourse_staging" {
   default = "postgres15"
 }
 
+variable "rds_force_ssl_concourse_staging" {
+  default = 1
+}
+
 variable "rds_db_engine_version_concourse_production" {
   default = "15.5"
 }
 
 variable "rds_parameter_group_family_concourse_production" {
   default = "postgres15"
+}
+
+variable "rds_force_ssl_concourse_production" {
+  default = 1
 }
 
 variable "rds_db_engine_version_opsuaa" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Postgres upgrade 15.12 - Concourse & Concourse credhub dbs 
- Enables `rds.force_ssl` to be controlled via the pipeline, all 4 RDS instances now have this on
- Part of https://github.com/cloud-gov/private/issues/2388
-

## Security considerations
Upgrades 4 RDS instances for concourse and concourse_credhub to latest postgres 15 release and enforces ssl, this should make the security folks happy.
