### PR TITLE
Add flag to control force_ssl for opsuaa

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -421,6 +421,7 @@ jobs:
 
           TF_VAR_rds_db_engine_version_opsuaa: "16.3"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
+          TF_VAR_rds_force_ssl_opsuaa: 0
           
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -14,6 +14,7 @@ module "opsuaa_db" {
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_db_engine_version           = var.rds_db_engine_version_opsuaa
   rds_parameter_group_family      = var.rds_parameter_group_family_opsuaa
+  rds_force_ssl                   = var.rds_force_ssl_opsuaa 
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
 }

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -14,7 +14,7 @@ module "opsuaa_db" {
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_db_engine_version           = var.rds_db_engine_version_opsuaa
   rds_parameter_group_family      = var.rds_parameter_group_family_opsuaa
-  rds_force_ssl                   = var.rds_force_ssl_opsuaa 
+  rds_force_ssl                   = var.rds_force_ssl_opsuaa
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -105,6 +105,10 @@ variable "rds_parameter_group_family_opsuaa" {
   default = "postgres16"
 }
 
+variable "rds_force_ssl_opsuaa" {
+  default = 1
+}
+
 variable "remote_state_bucket" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add flag to control force_ssl for opsuaa
- The custom parameter group currently has this set to 0
- Part of https://github.com/cloud-gov/private/issues/2391
-

## security considerations
Will be enabling rds.force_ssl on opsuaa and upgrading to 16.8 in a subsequent PR
