### PR TITLE
Add pg version and ssl control to pipeline for defectdojo

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -396,6 +396,14 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client: ((tooling_defectdojo_staging_oidc_client))
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
 
+          TF_VAR_rds_db_engine_version_defectdojo_development: "16.3"
+          TF_VAR_rds_parameter_group_family_defectdojo_development: "postgres16"
+          TF_VAR_rds_force_ssl_defectdojo_development: 0
+
+          TF_VAR_rds_db_engine_version_defectdojo_staging: "16.3"
+          TF_VAR_rds_parameter_group_family_defectdojo_staging: "postgres16"
+          TF_VAR_rds_force_ssl_defectdojo_staging: 0
+
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
           TF_VAR_rds_force_ssl_bosh: 1

--- a/terraform/modules/defect_dojo/rds.tf
+++ b/terraform/modules/defect_dojo/rds.tf
@@ -18,4 +18,5 @@ module "rds_96" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
+  rds_force_ssl                   = var.rds_force_ssl
 }

--- a/terraform/modules/defect_dojo/variables.tf
+++ b/terraform/modules/defect_dojo/variables.tf
@@ -90,3 +90,7 @@ variable "listener_arn" {
 variable "hosts" {
   type = list(string)
 }
+
+variable "rds_force_ssl" {
+  default = 1
+}

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -233,8 +233,9 @@ module "defectdojo_development" {
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-defectdojo-development"
-  rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo
-  rds_db_engine_version           = var.rds_db_engine_version_defectdojo
+  rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo_development
+  rds_db_engine_version           = var.rds_db_engine_version_defectdojo_development
+  rds_force_ssl                   = var.rds_force_ssl_defectdojo_development
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.t3.medium"
@@ -261,8 +262,9 @@ module "defectdojo_staging" {
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-defectdojo-staging"
-  rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo
-  rds_db_engine_version           = var.rds_db_engine_version_defectdojo
+  rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo_staging
+  rds_db_engine_version           = var.rds_db_engine_version_defectdojo_staging
+  rds_force_ssl                   = var.rds_force_ssl_defectdojo_staging
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -308,10 +308,26 @@ variable "aws_lb_listener_ssl_policy" {
   default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }
 
-variable "rds_db_engine_version_defectdojo" {
+variable "rds_db_engine_version_defectdojo_development" {
   default = "16.3"
 }
 
-variable "rds_parameter_group_family_defectdojo" {
+variable "rds_parameter_group_family_defectdojo_development" {
   default = "postgres16"
+}
+
+variable "rds_force_ssl_defectdojo_development" {
+  default = 1
+}
+
+variable "rds_db_engine_version_defectdojo_staging" {
+  default = "16.3"
+}
+
+variable "rds_parameter_group_family_defectdojo_staging" {
+  default = "postgres16"
+}
+
+variable "rds_force_ssl_defectdojo_staging" {
+  default = 1
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Exposes configuring the enforcement of ssl, postgres version and family down to TF_VARs in the pipeline
- Splits development & staging to be their own variables to control future db upgrades as separate steps
- Current value of rds.force_ssl in the custom parameter group is set to 0.  This, and the engine_version and family should reflect the current values and result of this should be no-ops in the plan-tooling job.
- Part of https://github.com/cloud-gov/private/issues/2390

## security considerations
Lays the groundwork for upgrading defect-dojo RDS instances and enabling ssl in a future PR
