### PR TITLE
Upgrade defect dojo to 16.8

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -396,13 +396,13 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client: ((tooling_defectdojo_staging_oidc_client))
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
 
-          TF_VAR_rds_db_engine_version_defectdojo_development: "16.3"
+          TF_VAR_rds_db_engine_version_defectdojo_development: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_development: "postgres16"
-          TF_VAR_rds_force_ssl_defectdojo_development: 0
+          TF_VAR_rds_force_ssl_defectdojo_development: 1
 
-          TF_VAR_rds_db_engine_version_defectdojo_staging: "16.3"
+          TF_VAR_rds_db_engine_version_defectdojo_staging: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_staging: "postgres16"
-          TF_VAR_rds_force_ssl_defectdojo_staging: 0
+          TF_VAR_rds_force_ssl_defectdojo_staging: 1
 
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Postgres upgrade 16.8 - Defect Dojo for development and staging
- The first part of this was https://github.com/cloud-gov/terraform-provision/pull/1880
- Part of https://github.com/cloud-gov/private/issues/2390

## Security Considerations
This is to upgraded the defect dojo RDS instances to 16.8 and enforce ssl usage
