### PR TITLE
ccdb force_ssl

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -532,6 +532,7 @@ jobs:
           TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_db_engine_version_cf: "16.3"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
+          TF_VAR_rds_force_ssl: 0
           TF_VAR_cf_rds_password: ((development_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((development_cf_as_rds_instance_type))
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
@@ -711,6 +712,7 @@ jobs:
           TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_db_engine_version_cf: "16.3"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
+          TF_VAR_rds_force_ssl: 0
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
@@ -899,6 +901,7 @@ jobs:
           TF_VAR_cf_as_rds_instance_type: ((production_cf_as_rds_instance_type))
           TF_VAR_rds_db_engine_version_cf: "16.3"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
+          TF_VAR_rds_force_ssl: 0
           TF_VAR_restricted_ingress_web_cidrs: ((production_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -14,4 +14,5 @@ module "cf_database_96" {
   rds_parameter_group_family      = var.rds_parameter_group_family
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
+  rds_force_ssl                   = var.rds_force_ssl
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -72,6 +72,10 @@ variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
 
+variable "rds_force_ssl" {
+  default = 1
+}
+
 variable "stack_prefix" {
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -265,6 +265,7 @@ module "cf" {
   stack_prefix               = "cf-${var.stack_description}"
   rds_db_engine_version      = var.rds_db_engine_version_cf
   rds_parameter_group_family = var.rds_parameter_group_family_cf
+  rds_force_ssl              = var.rds_force_ssl_cf
 
 
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -56,6 +56,10 @@ variable "rds_parameter_group_family_cf" {
   default = "postgres16"
 }
 
+variable "rds_force_ssl_cf" {
+  default = 1
+}
+
 variable "cf_rds_password" {
   sensitive = true
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding support to configure `rds.force_ssl` from the pipeline for each environment's CCDB
- This should be a no-op change, default to 1, override to 0 in the pipeline (which reflects what the parameter group currently has)
- Part of https://github.com/cloud-gov/private/issues/2392
-

## security considerations
This is a no-op change.  A subsequent PR will enable enforcement per environment.
