### PR TITLE
switch back to tooling load balancer

### DIFF
--- a/terraform/stacks/dns/dev-tooling.tf
+++ b/terraform/stacks/dns/dev-tooling.tf
@@ -4,7 +4,7 @@ resource "aws_route53_record" "cloud_gov_defectdojo_dev_cloud_gov_a" {
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -16,7 +16,7 @@ resource "aws_route53_record" "cloud_gov_defectdojo_dev_cloud_gov_aaaa" {
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch dev defectdojo back to the tooling load balancer


## security considerations
Tooling load balancer is now updated so we can switch dev defectdojo back to it
