### PR TITLE
Upgrade RDS for dev/staging CCDB and enable force ssl

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -531,9 +531,9 @@ jobs:
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
           TF_VAR_rds_force_ssl: 1
-          TF_VAR_rds_db_engine_version_cf: "16.3"
+          TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
-          TF_VAR_rds_force_ssl_cf: 0
+          TF_VAR_rds_force_ssl_cf: 1
           TF_VAR_cf_rds_password: ((development_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((development_cf_as_rds_instance_type))
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
@@ -711,9 +711,9 @@ jobs:
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
           TF_VAR_rds_force_ssl: 1
-          TF_VAR_rds_db_engine_version_cf: "16.3"
+          TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
-          TF_VAR_rds_force_ssl_cf: 0
+          TF_VAR_rds_force_ssl_cf: 1
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Sets RDS version for development and staging CCDB to 16.8
- Configures `rds.force_ssl` from the pipeline for development and staging CCDB
- This should be a no-op change, default to 1, override to 1 in the pipeline (which reflects what the parameter group currently has) for development and staging
- Part of https://github.com/cloud-gov/private/issues/2392
-

## security considerations
This is a no-op change, already applied.  
