### PR TITLE
Add pgcrypto to Credhub RDS instances for stage, prod, tooling

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -465,6 +465,21 @@ jobs:
                   - -e
                   - -c
                   - cg-provision-repo/ci/scripts/update-bosh-db.sh
+          - task: init-bosh-credhub-db
+            image: general-task
+            config:
+              platform: linux
+              inputs:
+                - name: cg-provision-repo
+                - name: terraform-state
+              params:
+                STATE_FILE_PATH: terraform-state/terraform.tfstate
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - cg-provision-repo/ci/scripts/update-bosh-credhub-db.sh
           - task: init-opsuaa-db
             image: general-task
             config:
@@ -613,21 +628,21 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-bosh-db.sh
-          - task: init-bosh-credhub-db
-            image: general-task
-            config:
-              platform: linux
-              inputs:
-                - name: cg-provision-repo
-                - name: terraform-state
-              params:
-                STATE_FILE_PATH: terraform-state/terraform.tfstate
-              run:
-                path: sh
-                args:
-                  - -e
-                  - -c
-                  - cg-provision-repo/ci/scripts/update-bosh-credhub-db.sh
+              - task: init-bosh-credhub-db
+                image: general-task
+                config:
+                  platform: linux
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-bosh-credhub-db.sh
               - task: init-cf-db
                 image: general-task
                 config:
@@ -808,6 +823,21 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-bosh-db.sh
+              - task: init-bosh-credhub-db
+                image: general-task
+                config:
+                  platform: linux
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-bosh-credhub-db.sh
               - task: init-cf-db
                 image: general-task
                 config:
@@ -986,6 +1016,21 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-bosh-db.sh
+              - task: init-bosh-credhub-db
+                image: general-task
+                config:
+                  platform: linux
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-bosh-credhub-db.sh
               - task: init-cf-db
                 image: general-task
                 config:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a pipeline task to update the bosh credhub rds instance in staging, production and tooling to our existing `create-and-update.sh` specs already used by BOSH, CF and OpsUAA databases.  The desired outcome is the pgcrypto db extension is colocated on each user database on the instance and therefore will pass CIS benchmark scans in Nessus.
- Dev PR added the script: https://github.com/cloud-gov/terraform-provision/pull/1899
- Part of https://github.com/cloud-gov/private/issues/2404
-

## security considerations
Brings us closer to CIS benchmark compliance for RDS for these instances
