### PR TITLE
Add pgcrypto to concourse production db

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -525,6 +525,21 @@ jobs:
                   - -e
                   - -c
                   - cg-provision-repo/ci/scripts/update-concourse-stage-db.sh
+          - task: init-concourse-prod-db
+            image: general-task
+            config:
+              platform: linux
+              inputs:
+                - name: cg-provision-repo
+                - name: terraform-state
+              params:
+                STATE_FILE_PATH: terraform-state/terraform.tfstate
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - cg-provision-repo/ci/scripts/update-concourse-prod-db.sh
           - task: init-opsuaa-db
             image: general-task
             config:

--- a/ci/scripts/update-concourse-prod-db.sh
+++ b/ci/scripts/update-concourse-prod-db.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+# Check environment variables
+export DATABASES="atc"
+export STATE_FILE_PATH="${STATE_FILE_PATH}"
+export TERRAFORM="${TERRAFORM_BIN:-terraform}"
+export TERRAFORM_DB_HOST_FIELD="production_concourse_rds_host"
+export TERRAFORM_DB_USERNAME_FIELD="production_concourse_rds_username"
+export TERRAFORM_DB_PASSWORD_FIELD="production_concourse_rds_password"
+
+"$SCRIPTPATH"/create-and-update-db.sh


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a pipeline task to update the concourse rds instance in production to our existing `create-and-update.sh` specs already used by BOSH, CF and OpsUAA databases.  The desired outcome is the pgcrypto db extension is colocated on each user database on the instance and therefore will pass CIS benchmark scans in Nessus.
- Part of https://github.com/cloud-gov/private/issues/2404
-

## security considerations
Brings us closer to CIS benchmark compliance for RDS for this instance
