### PR TITLE
Add pgcrypto to cf autoscaler RDS instances

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -719,6 +719,22 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-cf-db.sh
+              - task: init-cf-autoscaler-db
+                image: general-task
+                config:
+                  platform: linux
+                  image_resource:
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-cf-autoscaler-db.sh
           - do:
               - task: terraform-state-to-yaml
                 file: pipeline-tasks/terraform12-state-to-yaml.yml
@@ -913,6 +929,22 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-cf-db.sh
+              - task: init-cf-autoscaler-db
+                image: general-task
+                config:
+                  platform: linux
+                  image_resource:
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-cf-autoscaler-db.sh
           - do:
               - task: terraform-state-to-yaml
                 file: pipeline-tasks/terraform12-state-to-yaml.yml
@@ -1106,6 +1138,22 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-cf-db.sh
+              - task: init-cf-autoscaler-db
+                image: general-task
+                config:
+                  platform: linux
+                  image_resource:
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-cf-autoscaler-db.sh
       - do:
           - task: terraform-state-to-yaml
             file: pipeline-tasks/terraform12-state-to-yaml.yml

--- a/ci/scripts/update-cf-autoscaler-db.sh
+++ b/ci/scripts/update-cf-autoscaler-db.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+# Check environment variables
+export DATABASES="autoscaler"
+export STATE_FILE_PATH="${STATE_FILE_PATH}"
+export TERRAFORM="${TERRAFORM_BIN:-terraform}"
+export TERRAFORM_DB_HOST_FIELD="cf_as_rds_host"
+export TERRAFORM_DB_USERNAME_FIELD="cf_as_rds_username"
+export TERRAFORM_DB_PASSWORD_FIELD="cf_as_rds_password"
+
+"$SCRIPTPATH"/create-and-update-db.sh


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a pipeline task to update the cf autoscaler RDS instances to our existing `create-and-update.sh` specs already used by BOSH, CF and OpsUAA databases.  The desired outcome is the pgcrypto db extension is colocated on each user database on the instance and therefore will pass CIS benchmark scans in Nessus.
- Part of https://github.com/cloud-gov/private/issues/2404
-

## security considerations
Brings us closer to CIS benchmark compliance for RDS for this instance

