### PR TITLE
Adding generic update db script

### DIFF
--- a/ci/scripts/update-db.sh
+++ b/ci/scripts/update-db.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+# Check environment variables
+export DATABASES="${DATABASES}"
+export STATE_FILE_PATH="${STATE_FILE_PATH}"
+export TERRAFORM="${TERRAFORM_BIN:-terraform}"
+export TERRAFORM_DB_HOST_FIELD="${DB_HOST}"
+export TERRAFORM_DB_USERNAME_FIELD="${DB_USERNAME}"
+export TERRAFORM_DB_PASSWORD_FIELD="${DB_PASSWORD}"
+
+"$SCRIPTPATH"/create-and-update-db.sh


### PR DESCRIPTION
## Changes proposed in this pull request:
- Creating a generic `update db` script which will take in the list of dbs, host, user and pass from the pipeline instead of an almost identical set of `update-blah-db.sh` scripts.  Less code to maintain.  Will follow the same pattern as `STATE_FILE_PATH`.
- There will be a separate PR for `pipeline.yml` as it is verified this works.
- Part of https://github.com/cloud-gov/private/issues/2406
-

## security considerations
No changes to security, moving around where variables are used
