### PR TITLE
Add pgcrypto to defect dojo and domains_broker RDS instances

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -585,6 +585,45 @@ jobs:
                   - -e
                   - -c
                   - cg-provision-repo/ci/scripts/update-db.sh
+          - task: init-defectdojo-development-db
+            image: general-task
+            config:
+              platform: linux
+              inputs:
+                - name: cg-provision-repo
+                - name: terraform-state
+              params:
+                STATE_FILE_PATH: terraform-state/terraform.tfstate
+                DATABASES: dojo
+                TERRAFORM_DB_HOST_FIELD: development_defectdojo_rds_host
+                TERRAFORM_DB_USERNAME_FIELD: development_defectdojo_rds_username
+                TERRAFORM_DB_PASSWORD_FIELD: development_defectdojo_rds_password
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - cg-provision-repo/ci/scripts/update-db.sh
+          - task: init-defectdojo-staging-db
+            image: general-task
+            config:
+              platform: linux
+              inputs:
+                - name: cg-provision-repo
+                - name: terraform-state
+              params:
+                STATE_FILE_PATH: terraform-state/terraform.tfstate
+                DATABASES: dojo
+                TERRAFORM_DB_HOST_FIELD: staging_defectdojo_rds_host
+                TERRAFORM_DB_USERNAME_FIELD: staging_defectdojo_rds_username
+                TERRAFORM_DB_PASSWORD_FIELD: staging_defectdojo_rds_password
+              run:
+                path: sh
+                args:
+                  - -e
+                  - -c
+                  - cg-provision-repo/ci/scripts/update-db.sh
+
           - do:
               - task: terraform-state-to-yaml
                 file: pipeline-tasks/terraform12-state-to-yaml.yml
@@ -775,6 +814,26 @@ jobs:
                     TERRAFORM_DB_HOST_FIELD: cf_as_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_as_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_as_rds_password
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-db.sh
+              - task: init-domains_broker-db
+                image: general-task
+                config:
+                  platform: linux
+                  image_resource:
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                    DATABASES: domains_broker
+                    TERRAFORM_DB_HOST_FIELD: domains_broker_rds_address
+                    TERRAFORM_DB_USERNAME_FIELD: domains_broker_rds_username
+                    TERRAFORM_DB_PASSWORD_FIELD: domains_broker_rds_password
                   run:
                     path: sh
                     args:
@@ -1008,6 +1067,26 @@ jobs:
                       - -e
                       - -c
                       - cg-provision-repo/ci/scripts/update-db.sh
+              - task: init-domains_broker-db
+                image: general-task
+                config:
+                  platform: linux
+                  image_resource:
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                    DATABASES: domains_broker
+                    TERRAFORM_DB_HOST_FIELD: domains_broker_rds_address
+                    TERRAFORM_DB_USERNAME_FIELD: domains_broker_rds_username
+                    TERRAFORM_DB_PASSWORD_FIELD: domains_broker_rds_password
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-db.sh
           - do:
               - task: terraform-state-to-yaml
                 file: pipeline-tasks/terraform12-state-to-yaml.yml
@@ -1228,6 +1307,26 @@ jobs:
                     TERRAFORM_DB_HOST_FIELD: cf_as_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_as_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_as_rds_password
+                  run:
+                    path: sh
+                    args:
+                      - -e
+                      - -c
+                      - cg-provision-repo/ci/scripts/update-db.sh
+              - task: init-domains_broker-db
+                image: general-task
+                config:
+                  platform: linux
+                  image_resource:
+                  inputs:
+                    - name: cg-provision-repo
+                    - name: terraform-state
+                  params:
+                    STATE_FILE_PATH: terraform-state/terraform.tfstate
+                    DATABASES: domains_broker
+                    TERRAFORM_DB_HOST_FIELD: domains_broker_rds_address
+                    TERRAFORM_DB_USERNAME_FIELD: domains_broker_rds_username
+                    TERRAFORM_DB_PASSWORD_FIELD: domains_broker_rds_password
                   run:
                     path: sh
                     args:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add pipeline tasks to "init db" the RDS instances for Defect Dojo (development and staging) and Domains Broker (development, staging and production)
- Already run in `apply-env` and verified the results
- Part of https://github.com/cloud-gov/private/issues/2406

## security considerations
Needed for CIS Benchmark requirements for pgcypto in Nessus scans
