### PR TITLE
CCDB - Upgrade prod to 16.8 and enable force ssl

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1179,9 +1179,9 @@ jobs:
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((production_cf_as_rds_instance_type))
-          TF_VAR_rds_db_engine_version_cf: "16.3"
+          TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
-          TF_VAR_rds_force_ssl_cf: 0
+          TF_VAR_rds_force_ssl_cf: 1
           TF_VAR_restricted_ingress_web_cidrs: ((production_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- Upgrade of RDS database in prod to 16.8, this was already done in AWS Console, this catches the pipeline up
- Enables force_ssl on prod
- Dev/Staging was a separate PR
- Part of https://github.com/cloud-gov/private/issues/2392

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This upgrades to the most recent 16.x RDS Postgres version and forces SSL connections