### PR TITLE
move the order of the ipv6 rule

### DIFF
--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -417,12 +417,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
         statement {
           ip_set_reference_statement {
-            arn = var.gsa_ipv6_range_ip_set_arn
-          }
-        }
-
-        statement {
-          ip_set_reference_statement {
             arn = var.customer_whitelist_source_ip_ranges_set_arn
           }
         }
@@ -442,18 +436,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
         statement {
           ip_set_reference_statement {
             arn = var.gsa_ip_range_ip_set_arn
-
-            ip_set_forwarded_ip_config {
-              header_name       = var.forwarded_ip_header_name
-              fallback_behavior = "NO_MATCH"
-              position          = "FIRST"
-            }
-          }
-        }
-
-        statement {
-          ip_set_reference_statement {
-            arn = var.gsa_ipv6_range_ip_set_arn
 
             ip_set_forwarded_ip_config {
               header_name       = var.forwarded_ip_header_name
@@ -496,6 +478,12 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
               fallback_behavior = "NO_MATCH"
               position          = "FIRST"
             }
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
+            arn = var.gsa_ipv6_range_ip_set_arn
           }
         }
       }

--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -481,6 +481,8 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
           }
         }
 
+        statement {when I was a young warthog...}
+
         statement {
           ip_set_reference_statement {
             arn = var.gsa_ipv6_range_ip_set_arn

--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -469,19 +469,18 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
           }
         }
 
-        statement {
-          ip_set_reference_statement {
-            arn = var.customer_whitelist_ip_ranges_set_arn
-
-            ip_set_forwarded_ip_config {
-              header_name       = var.forwarded_ip_header_name
-              fallback_behavior = "NO_MATCH"
-              position          = "FIRST"
-            }
-          }
-        }
-
-        statement {when I was a young warthog...}
+#        statement {
+#          ip_set_reference_statement {
+#            arn = var.customer_whitelist_ip_ranges_set_arn
+#
+#            ip_set_forwarded_ip_config {
+#              header_name       = var.forwarded_ip_header_name
+#              fallback_behavior = "NO_MATCH"
+#              position          = "FIRST"
+#            }
+#          }
+#        }
+#
 
         statement {
           ip_set_reference_statement {

--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   lifecycle {
     # Regarding rule: If you make updates to the WAF rules in this file, you must remove `rule` so they apply.
     # This is a workaround to an issue: https://github.com/hashicorp/terraform-provider-aws/issues/33124
-    ignore_changes = [rule, tags_all]
+    ignore_changes = [tags_all]
   }
 
   default_action {

--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -469,22 +469,15 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
           }
         }
 
-#        statement {
-#          ip_set_reference_statement {
-#            arn = var.customer_whitelist_ip_ranges_set_arn
-#
-#            ip_set_forwarded_ip_config {
-#              header_name       = var.forwarded_ip_header_name
-#              fallback_behavior = "NO_MATCH"
-#              position          = "FIRST"
-#            }
-#          }
-#        }
-#
-
         statement {
           ip_set_reference_statement {
-            arn = var.gsa_ipv6_range_ip_set_arn
+            arn = var.customer_whitelist_ip_ranges_set_arn
+
+            ip_set_forwarded_ip_config {
+              header_name       = var.forwarded_ip_header_name
+              fallback_behavior = "NO_MATCH"
+              position          = "FIRST"
+            }
           }
         }
       }
@@ -496,6 +489,34 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    name     = "AllowTrustedv6IPs"
+    priority = 65
+
+    action {
+      allow {}
+    }
+
+    statement {
+      or_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = var.gsa_ipv6_range_ip_set_arn
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.stack_description}-AllowTrustedv6IPs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+
+
 
   dynamic "rule" {
     for_each = toset(local.malicious_ja3_fingerprint_rules)


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moved the gsa_ipv6 to the bottom of the rule list
- Removed the extra one looking at the header
- Git diff is showing goofy because of the reorder
- Attempt to fix https://github.com/cloud-gov/terraform-provision/pull/1917

## security considerations
Should be no different than https://github.com/cloud-gov/terraform-provision/pull/1917
