### PR TITLE
feat: Add test site domains for Pages staging and dev

### DIFF
--- a/terraform/stacks/dns/pages.tf
+++ b/terraform/stacks/dns/pages.tf
@@ -167,6 +167,25 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_staging_cloud_gov_aaaa
     evaluate_target_health = false
   }
 }
+
+## Staging Test Site ##
+
+resource "aws_route53_record" "cloud_gov_test-site_pages-staging_cloud_gov" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "test-site.pages-staging.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["test-site.pages-staging.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov__acme-challenge_test-site_pages-staging_cloud_gov" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "_acme-challenge.test-site.pages-staging.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.test-site.pages-staging.cloud.gov.external-domains-production.cloud.gov."]
+}
+
 ## End Staging ##
 
 #################
@@ -227,4 +246,23 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_dev_cloud_gov_aaaa" {
     evaluate_target_health = false
   }
 }
+
+## Dev Test Site ##
+
+resource "aws_route53_record" "cloud_gov_test-site_pages-dev_cloud_gov" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "test-site.pages-dev.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["test-site.pages-dev.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov__acme-challenge_test-site_pages-dev_cloud_gov" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "_acme-challenge.test-site.pages-dev.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.test-site.pages-dev.cloud.gov.external-domains-production.cloud.gov."]
+}
+
 ## End Development ##


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds test-site.pages-staging.cloud.gov to deploy an external domain in Pages staging for testing
- Adds test-site.pages-dev.cloud.gov to deploy an external domain in Pages dev for testing

## security considerations
Adds testing domains for the Pages dev and staging environments to mimic a customer with a custom site domain
