### PR TITLE
update health check endpoint for defectdojo

### DIFF
--- a/terraform/modules/defect_dojo/elb.tf
+++ b/terraform/modules/defect_dojo/elb.tf
@@ -10,6 +10,7 @@ resource "aws_lb_target_group" "defectdojo_target" {
     timeout             = 5
     interval            = 30
     matcher             = 200
+    path                = "/login?force_login_form"
   }
 
   stickiness {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update endpoint for defectdojo to one that will return a 200 instead of a 302 redirect

## security considerations
Updating health check so we can properly identify that defectdojo is reachable
