### PR TITLE
Address issues with broker failing when user is missing

### DIFF
--- a/terraform/modules/iam_role_policy/s3_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.tf
@@ -15,12 +15,10 @@ data "aws_iam_policy_document" "s3_broker_policy" {
       "iam:GetUser",
       "iam:CreateUser",
       "iam:DeleteUser",
-      "iam:ListAccessKeys",
       "iam:CreateAccessKey",
       "iam:DeleteAccessKey",
       "iam:CreatePolicy",
       "iam:DeletePolicy",
-      "iam:ListAttachedUserPolicies",
       "iam:AttachUserPolicy",
       "iam:DetachUserPolicy",
       "iam:TagUser",
@@ -33,6 +31,16 @@ data "aws_iam_policy_document" "s3_broker_policy" {
       "arn:${var.aws_partition}:iam::${var.account_id}:user${var.iam_path}*",
       "arn:${var.aws_partition}:iam::${var.account_id}:policy${var.iam_path}",
       "arn:${var.aws_partition}:iam::${var.account_id}:policy${var.iam_path}*"
+    ]
+  }
+  statement {
+    actions = [
+        "iam:ListAccessKeys",
+        "iam:ListAttachedUserPolicies"
+    ]
+
+    resources = [ 
+        "arn:${var.aws_partition}:iam::${var.account_id}:user/*"
     ]
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.tf
@@ -35,12 +35,12 @@ data "aws_iam_policy_document" "s3_broker_policy" {
   }
   statement {
     actions = [
-        "iam:ListAccessKeys",
-        "iam:ListAttachedUserPolicies"
+      "iam:ListAccessKeys",
+      "iam:ListAttachedUserPolicies"
     ]
 
-    resources = [ 
-        "arn:${var.aws_partition}:iam::${var.account_id}:user/*"
+    resources = [
+      "arn:${var.aws_partition}:iam::${var.account_id}:user/*"
     ]
   }
 }


### PR DESCRIPTION
The s3 broker fails to unbind if the underlying IAM user has been deleted or somehow failed to be instantiated.

To prevent AccessDenied issues, we'll let ListAccessKeys and ListAttachedUsersPolicies fail with a NotFound by granting them access to all users.

The alternative would be more permissions for GetUsers or ListUsers, which would require a code rewrite, and those permissions  leak more information if this IAM role were to be compromised

Also, ListAccessKeys and ListAttachedUserPolicies only apply to `user` resources so it's fine to remove them from the existing statement.



## security considerations
Regarding `GetUser` vs the other API calls:

```
aws iam get-user --user cg-s3-deidentfied-guid | grep Key
                "Key": "Service offering name",
                "Key": "Instance GUID",
                "Key": "Space GUID",
                "Key": "environment",
                "Key": "Created at",
                "Key": "broker",
                "Key": "Service plan name",
                "Key": "Space name",
                "Key": "Organization GUID",
                "Key": "Organization name",
                "Key": "client",
```
This seems like a lot of info. In comparison the other API calls don't get at as much....

```
❯ aws iam list-access-keys --user-name cg-s3-deidentfied-guid
{
    "AccessKeyMetadata": [
        {
            "UserName": "cg-s3-deidentfied-guid,
            "AccessKeyId": "AKIAFAKEFAKEFAKE",
            "Status": "Active",
            "CreateDate": "2025-01-07T18:11:32+00:00"
        }
    ]
}


❯ aws iam list-attached-user-policies --user-name cg-s3-deidentfied-guid
{
    "AttachedPolicies": [
        {
            "PolicyName": "cg-s3-deidentfied-guid",
            "PolicyArn": "arn:aws-us-gov:iam::(redacted)"
        }
    ]
}
```

