### PR TITLE
add ListUsers permission to s3 broker

### DIFF
--- a/terraform/modules/iam_role_policy/s3_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.tf
@@ -33,6 +33,19 @@ data "aws_iam_policy_document" "s3_broker_policy" {
       "arn:${var.aws_partition}:iam::${var.account_id}:policy${var.iam_path}*"
     ]
   }
+
+  statement {
+    actions = [
+      "iam:ListUsers"
+    ]
+
+    # Resource constraint cannot be used with ListUsers
+    # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsidentityandaccessmanagementiam.html#awsidentityandaccessmanagementiam-user
+    resources = [
+      "*"
+    ]
+  }
+
   statement {
     actions = [
       "iam:ListAccessKeys",


### PR DESCRIPTION
## Changes proposed in this pull request:

- add ListUsers permission to s3 broker, because doing ListUsers on `*` is required to run `DeleteUser` on users that no longer exist

## security considerations

This permission is read-only. [ListUsers cannot be scoped to a specific set of resources](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsidentityandaccessmanagementiam.html#awsidentityandaccessmanagementiam-user).
