### PR TITLE
Use GetUser to test for existence, not ListUser

### DIFF
--- a/terraform/modules/iam_role_policy/s3_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.tf
@@ -24,7 +24,9 @@ data "aws_iam_policy_document" "s3_broker_policy" {
       "iam:TagUser",
       "iam:UntagUser",
       "iam:TagPolicy",
-      "iam:UntagPolicy"
+      "iam:UntagPolicy",
+      "iam:ListAccessKeys",
+      "iam:ListAttachedUserPolicies"
     ]
 
     resources = [
@@ -36,24 +38,11 @@ data "aws_iam_policy_document" "s3_broker_policy" {
 
   statement {
     actions = [
-      "iam:ListUsers"
-    ]
-
-    # Resource constraint cannot be used with ListUsers
-    # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsidentityandaccessmanagementiam.html#awsidentityandaccessmanagementiam-user
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "iam:ListAccessKeys",
-      "iam:ListAttachedUserPolicies"
+      "iam:GetUser"
     ]
 
     resources = [
-      "arn:${var.aws_partition}:iam::${var.account_id}:user/*"
+      "arn:${var.aws_partition}:iam::${var.account_id}:user/${var.s3-user-prefix}"
     ]
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "s3_broker_policy" {
     ]
 
     resources = [
-      "arn:${var.aws_partition}:iam::${var.account_id}:user/${var.s3-user-prefix}"
+      "arn:${var.aws_partition}:iam::${var.account_id}:user/${var.s3_user_prefix}"
     ]
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/variables.tf
@@ -13,3 +13,7 @@ variable "bucket_prefix" {
 variable "iam_path" {
   default = "/"
 }
+
+variable "s3-user-prefix" {
+  default = "/cg-s3-*"
+}

--- a/terraform/modules/iam_role_policy/s3_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/variables.tf
@@ -14,6 +14,6 @@ variable "iam_path" {
   default = "/"
 }
 
-variable "s3-user-prefix" {
+variable "s3_user_prefix" {
   default = "/cg-s3-*"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

We decided against ListUser for testing user existence since we'd have to iterate overall 1200+.

GetUser currently succeeds in most cases because the user we're testing for exists, and it's at the path specifed with `var.iam_path`.

However, if the user is absent, GetUser fails because there's no path to it. In that case we need to check for user with the `var.s3_user_prefix`.

See also https://github.com/cloud-gov/s3-broker/pull/99 for CI tests

-

## security considerations
See above for discussion of scope of perm changes. 
