### PR TITLE
Separate out STIG RDS changes to apply only to csb/stig_broker

### DIFF
--- a/terraform/modules/csb/broker_stig/main.tf
+++ b/terraform/modules/csb/broker_stig/main.tf
@@ -1,0 +1,22 @@
+// Use the RDS module instead of brokering a database inside Cloud Foundry.
+// Eventually the CSB itself will broker RDS, so this avoids a circular dependency.
+// 2025-05-12 - Using the `rds_stig` while we're hardening, and then we'll merge
+// these changes back into `rds`
+module "db" {
+  source = "../../rds_stig"
+
+  stack_description               = var.stack_description
+  rds_instance_type               = var.rds_instance_type
+  rds_db_size                     = var.rds_db_size
+  rds_db_engine                   = var.rds_db_engine
+  rds_db_engine_version           = var.rds_db_engine_version
+  rds_db_name                     = var.rds_db_name
+  rds_username                    = var.rds_username
+  rds_password                    = var.rds_password
+  rds_subnet_group                = var.rds_subnet_group
+  rds_security_groups             = var.rds_security_groups
+  rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_apply_immediately           = var.rds_apply_immediately
+  rds_require_secure_transport    = var.rds_require_secure_transport
+}

--- a/terraform/modules/csb/broker_stig/outputs.tf
+++ b/terraform/modules/csb/broker_stig/outputs.tf
@@ -1,0 +1,24 @@
+output "rds_host" {
+  value = module.db.rds_host
+}
+
+output "rds_port" {
+  value = module.db.rds_port
+}
+
+output "rds_url" {
+  value = module.db.rds_url
+}
+
+output "rds_name" {
+  value = module.db.rds_name
+}
+
+output "rds_username" {
+  value = module.db.rds_username
+}
+
+output "rds_password" {
+  value     = module.db.rds_password
+  sensitive = true
+}

--- a/terraform/modules/csb/broker_stig/variables.tf
+++ b/terraform/modules/csb/broker_stig/variables.tf
@@ -1,0 +1,65 @@
+variable "stack_description" {
+  type        = string
+  description = "Like development, staging, or production."
+}
+
+# RDS variables
+
+variable "rds_instance_type" {
+  type    = string
+  default = "db.t3.small"
+}
+
+variable "rds_db_size" {
+  type    = number
+  default = 20
+}
+
+variable "rds_db_name" {
+  type    = string
+  default = "csb"
+}
+
+variable "rds_db_engine" {
+  type    = string
+  default = "mysql"
+}
+
+variable "rds_db_engine_version" {
+  type    = string
+  default = "8.0"
+}
+
+variable "rds_parameter_group_family" {
+  type    = string
+  default = "mysql8.0"
+}
+
+variable "rds_username" {
+  type    = string
+  default = "csb"
+}
+
+variable "rds_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "rds_subnet_group" {
+}
+
+variable "rds_security_groups" {
+  type = list(string)
+}
+
+variable "rds_apply_immediately" {
+  default = "false"
+}
+
+variable "rds_allow_major_version_upgrade" {
+  default = "false"
+}
+
+variable "rds_require_secure_transport" {
+  default = 1
+}

--- a/terraform/modules/csb/broker_stig/versions.tf
+++ b/terraform/modules/csb/broker_stig/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "< 1.0"
+    }
+  }
+}

--- a/terraform/modules/rds_stig/database.tf
+++ b/terraform/modules/rds_stig/database.tf
@@ -1,0 +1,44 @@
+resource "aws_db_instance" "rds_database" {
+  engine         = var.rds_db_engine
+  engine_version = var.rds_db_engine_version
+
+  multi_az = var.rds_multi_az
+
+  lifecycle {
+    ignore_changes  = [identifier]
+    prevent_destroy = true
+  }
+
+  identifier = "${var.stack_description}-${element(split("-", uuid()), 4)}"
+
+  final_snapshot_identifier = var.rds_final_snapshot_identifier == "" ? "final-snapshot-${var.rds_db_name}-${var.stack_description}" : var.rds_final_snapshot_identifier
+
+  backup_retention_period = 35
+
+  auto_minor_version_upgrade = true
+
+  db_name           = var.rds_db_name
+  allocated_storage = var.rds_db_size
+  storage_type      = var.rds_db_storage_type
+  iops              = var.rds_db_iops
+  instance_class    = var.rds_instance_type
+
+  username = var.rds_username
+  password = var.rds_password
+
+  storage_encrypted = true
+
+  db_subnet_group_name   = var.rds_subnet_group
+  vpc_security_group_ids = var.rds_security_groups
+
+  performance_insights_enabled = var.performance_insights_enabled
+
+  parameter_group_name = var.rds_db_engine == "postgres" ? join("", aws_db_parameter_group.parameter_group_postgres.*.id) : join("", aws_db_parameter_group.parameter_group_mysql.*.id)
+
+  allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  apply_immediately           = var.rds_apply_immediately
+
+  tags = {
+    Name = var.stack_description
+  }
+}

--- a/terraform/modules/rds_stig/outputs.tf
+++ b/terraform/modules/rds_stig/outputs.tf
@@ -1,0 +1,32 @@
+output "rds_identifier" {
+  value = aws_db_instance.rds_database.identifier
+}
+
+output "rds_name" {
+  value = aws_db_instance.rds_database.db_name
+}
+
+output "rds_url" {
+  value = aws_db_instance.rds_database.endpoint
+}
+
+output "rds_host" {
+  value = aws_db_instance.rds_database.address
+}
+
+output "rds_port" {
+  value = aws_db_instance.rds_database.port
+}
+
+output "rds_username" {
+  value = aws_db_instance.rds_database.username
+}
+
+output "rds_password" {
+  value     = aws_db_instance.rds_database.password
+  sensitive = true
+}
+
+output "rds_engine" {
+  value = aws_db_instance.rds_database.engine
+}

--- a/terraform/modules/rds_stig/parameter_group.tf
+++ b/terraform/modules/rds_stig/parameter_group.tf
@@ -1,0 +1,61 @@
+resource "aws_db_parameter_group" "parameter_group_postgres" {
+  count = var.rds_db_engine == "postgres" ? 1 : 0
+  name = var.rds_parameter_group_name != "" ? var.rds_parameter_group_name : replace(
+    "${var.stack_description}-${var.rds_db_name}",
+    "/[^a-zA-Z-]+/",
+    "-",
+  )
+
+  family = var.rds_parameter_group_family
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = "1"
+  }
+
+  parameter {
+    name  = "log_hostname"
+    value = "0"
+  }
+
+  parameter {
+    name  = "log_statement"
+    value = "ddl"
+  }
+
+  parameter {
+    name         = "rds.force_ssl"
+    value        = var.rds_force_ssl
+    apply_method = "pending-reboot"
+  }
+}
+
+resource "aws_db_parameter_group" "parameter_group_mysql" {
+  count = var.rds_db_engine == "mysql" ? 1 : 0
+  name = var.rds_parameter_group_name != "" ? var.rds_parameter_group_name : replace(
+    "${var.stack_description}-${var.rds_db_name}",
+    "/[^a-zA-Z-]+/",
+    "-",
+  )
+
+  family = var.rds_parameter_group_family
+  parameter {
+    name  = "general_log"
+    value = 1
+  }
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+
+  # This can apply immediately
+  parameter {
+    name  = "require_secure_transport"
+    value = var.rds_require_secure_transport
+  }
+}

--- a/terraform/modules/rds_stig/variables.tf
+++ b/terraform/modules/rds_stig/variables.tf
@@ -1,0 +1,96 @@
+variable "stack_description" {
+}
+
+variable "rds_instance_type" {
+  default = "db.m5.large"
+}
+
+variable "rds_db_size" {
+  default = 20
+}
+
+variable "rds_db_storage_type" {
+  default = "gp3"
+}
+
+variable "rds_db_iops" {
+  default = null
+}
+
+variable "rds_db_name" {
+}
+
+variable "rds_db_engine" {
+  default = "postgres"
+}
+
+variable "rds_db_engine_version" {
+  default = "12.17"
+}
+
+variable "rds_username" {
+}
+
+variable "rds_password" {
+  sensitive = true
+}
+
+variable "rds_subnet_group" {
+}
+
+variable "rds_security_groups" {
+  type = list(string)
+}
+
+# postgres only
+variable "rds_force_ssl" {
+  default = 0
+}
+
+# mysql only
+variable "rds_require_secure_transport" {
+  default = 0
+}
+
+variable "rds_parameter_group_name" {
+  default = ""
+}
+
+variable "rds_parameter_group_family" {
+  default = "postgres12"
+}
+
+variable "rds_multi_az" {
+  default = "true"
+}
+
+variable "rds_final_snapshot_identifier" {
+  default = ""
+}
+
+# Used in combination, these two flags allow for immediate upgrade of RDS
+# instances across major versions. They should be used temporarily:
+#
+# 1. Set both to `true` and apply the configuration.
+# 1. Upgrade the DB version and apply.
+# 1. Set both to `false` and apply a third time.
+#
+# Also, please be cautious when upgrading, and follow the documented best
+# practices:
+#
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion.Process
+# https://aws.amazon.com/blogs/database/best-practices-for-upgrading-amazon-rds-to-major-and-minor-versions-of-postgresql/
+#
+variable "rds_apply_immediately" {
+  # Even though the documentation says these default to "false", `terraform
+  # plan` shows otherwise.
+  default = "false"
+}
+
+variable "rds_allow_major_version_upgrade" {
+  default = "false"
+}
+
+variable "performance_insights_enabled" {
+  default = "false"
+}

--- a/terraform/modules/rds_stig/versions.tf
+++ b/terraform/modules/rds_stig/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+  }
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -467,6 +467,7 @@ resource "random_password" "csb_rds_password" {
 }
 
 module "csb_broker" {
+  count             = var.stack_description != "development" ? 2 : 0
   source            = "../../modules/csb/broker"
   stack_description = var.stack_description
 
@@ -477,6 +478,29 @@ module "csb_broker" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_instance_type               = var.csb_rds_instance_type
 }
+
+resource "random_password" "csb_rds_stig_password" {
+  length      = 32
+  special     = true
+  min_special = 2
+  min_upper   = 5
+  min_numeric = 5
+  min_lower   = 5
+}
+
+module "csb_stig_broker" {
+  count             = var.stack_description == "development" ? 1 : 0
+  source            = "../../modules/csb/broker_stig"
+  stack_description = var.stack_description
+
+  rds_password                    = random_password.csb_rds_stig_password.result
+  rds_subnet_group                = module.stack.rds_subnet_group
+  rds_security_groups             = [module.stack.rds_mysql_security_group]
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_apply_immediately           = var.rds_apply_immediately
+  rds_instance_type               = var.csb_rds_instance_type
+}
+
 
 module "opensearch_proxy_redis_cluster" {
   source = "../../modules/elasticache_replication_group"


### PR DESCRIPTION
## Changes proposed in this pull request:

In discussion w/ @jameshochadel , this split out STIG hardening into the following copies of 
the original un-stig'd code:

- terraform/modules/csb/broker_stig
- terraform/modules/rds_stig

and updates [terraform/stacks/main/stack.tf] to add:

-  resource "random_password" "csb_rds_stig_password"
- module "csb_stig_broker" 

## security considerations
Safe. Adds no new functionality or secrets
