### PR TITLE
Upping certbot to 3.3.0

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -5,8 +5,8 @@ set -eu
 curl -L -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
 chmod +x ./jq
 
-pip install certbot==2.6.0
-pip install certbot-dns-route53==2.6.0
+pip install certbot==3.3.0
+pip install certbot-dns-route53==3.3.0
 
 #spruce_url=$(curl https://api.github.com/repos/geofffranks/spruce/releases/latest \
 #  | ./jq -r '.assets[] | select(.name == "spruce-linux-amd64") | .browser_download_url')

--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-curl -L -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-chmod +x ./jq
-
 pip install certbot==3.3.0
 pip install certbot-dns-route53==3.3.0
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updating certbot to work with newer versions of python and dependencies 
- Part of https://github.com/cloud-gov/product/issues/2836

## security considerations
Keeping up to date on old closes CVEs
