### PR TITLE
Pgaudit - CF Development with deployment instructions

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -703,6 +703,10 @@ jobs:
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_rds_force_ssl_cf: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_cf: true
+          TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter_cf: true
+          TF_VAR_rds_pgaudit_log_values_cf: "ddl,role"
           TF_VAR_cf_rds_password: ((development_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((development_cf_as_rds_instance_type))
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
@@ -817,6 +821,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: ccdb uaadb diegodb locketdb policydb silkdb routingdb
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: cf_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_rds_password

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -43,7 +43,7 @@ for db in ${DATABASES}; do
   psql_adm -d postgres -l | awk '{print $1}' | grep -q "${db}" || \
     psql_adm -d postgres -c "CREATE DATABASE ${db} OWNER ${db_user}"
   # Enable extensions
-  for ext in citext uuid-ossp pgcrypto pg_stat_statements; do
+  for ext in ${EXTENSIONS}; do
     psql_adm -d "${db}" -c "CREATE EXTENSION IF NOT EXISTS \"${ext}\""
   done
 

--- a/ci/scripts/update-db.sh
+++ b/ci/scripts/update-db.sh
@@ -4,6 +4,7 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 # Check environment variables
 export DATABASES="${DATABASES}"
+export EXTENSIONS="${CUSTOM_EXTENSIONS:-citext uuid-ossp pgcrypto pg_stat_statements}"
 export STATE_FILE_PATH="${STATE_FILE_PATH}"
 export TERRAFORM="${TERRAFORM_BIN:-terraform}"
 export TERRAFORM_DB_HOST_FIELD="${TERRAFORM_DB_HOST_FIELD}"

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -17,4 +17,6 @@ module "cf_database_96" {
   rds_force_ssl                               = var.rds_force_ssl
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
 }

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -1,18 +1,20 @@
 module "cf_database_96" {
   source = "../rds"
 
-  stack_description               = var.stack_description
-  rds_instance_type               = var.rds_instance_type
-  rds_db_size                     = var.rds_db_size
-  rds_db_engine                   = var.rds_db_engine
-  rds_db_engine_version           = var.rds_db_engine_version
-  rds_db_name                     = var.rds_db_name
-  rds_username                    = var.rds_username
-  rds_password                    = var.rds_password
-  rds_subnet_group                = var.rds_subnet_group
-  rds_security_groups             = var.rds_security_groups
-  rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
-  rds_apply_immediately           = var.rds_apply_immediately
-  rds_force_ssl                   = var.rds_force_ssl
+  stack_description                           = var.stack_description
+  rds_instance_type                           = var.rds_instance_type
+  rds_db_size                                 = var.rds_db_size
+  rds_db_engine                               = var.rds_db_engine
+  rds_db_engine_version                       = var.rds_db_engine_version
+  rds_db_name                                 = var.rds_db_name
+  rds_username                                = var.rds_username
+  rds_password                                = var.rds_password
+  rds_subnet_group                            = var.rds_subnet_group
+  rds_security_groups                         = var.rds_security_groups
+  rds_parameter_group_family                  = var.rds_parameter_group_family
+  rds_allow_major_version_upgrade             = var.rds_allow_major_version_upgrade
+  rds_apply_immediately                       = var.rds_apply_immediately
+  rds_force_ssl                               = var.rds_force_ssl
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -267,3 +267,15 @@ variable "aws_lb_listener_ssl_policy" {
   type    = string
   default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -279,3 +279,4 @@ variable "rds_add_pgaudit_log_parameter" {
   type        = bool
   default     = false
 }
+

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -280,3 +280,12 @@ variable "rds_add_pgaudit_log_parameter" {
   default     = false
 }
 
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+}
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+}

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -283,9 +283,11 @@ variable "rds_add_pgaudit_log_parameter" {
 variable "rds_shared_preload_libraries" {
   description = "List of shared_preload_libraries to load"
   type        = string
+  default     = "pg_stat_statements"
 }
 
 variable "rds_pgaudit_log_values" {
   description = "List of statements that should be included in pgaudit logs"
   type        = string
+  default     = "none"
 }

--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   lifecycle {
     # Regarding rule: If you make updates to the WAF rules in this file, you must remove `rule` so they apply.
     # This is a workaround to an issue: https://github.com/hashicorp/terraform-provider-aws/issues/33124
-    ignore_changes = [rule,tags_all]
+    ignore_changes = [rule, tags_all]
   }
 
   default_action {

--- a/terraform/modules/cloudfoundry/waf.tf
+++ b/terraform/modules/cloudfoundry/waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   lifecycle {
     # Regarding rule: If you make updates to the WAF rules in this file, you must remove `rule` so they apply.
     # This is a workaround to an issue: https://github.com/hashicorp/terraform-provider-aws/issues/33124
-    ignore_changes = [tags_all]
+    ignore_changes = [rule,tags_all]
   }
 
   default_action {

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -38,7 +38,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
     for_each = var.rds_add_pgaudit_to_shared_preload_libraries ? [1] : []
     content {
       name  = "shared_preload_libraries"
-      value = "pgaudit,pg_stat_statements"
+      value = "pgaudit,pg_stat_statements,pg_tle"
     }
   }
 

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -37,16 +37,18 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
   dynamic "parameter" {
     for_each = var.rds_add_pgaudit_to_shared_preload_libraries ? [1] : []
     content {
-      name  = "shared_preload_libraries"
-      value = "pgaudit,pg_stat_statements,pg_tle"
+      name         = "shared_preload_libraries"
+      value        = var.rds_shared_preload_libraries
+      apply_method = "pending-reboot"
     }
   }
 
   dynamic "parameter" {
     for_each = var.rds_add_pgaudit_log_parameter ? [1] : []
     content {
-      name  = "pgaudit.log"
-      value = "ddl,role"
+      name         = "pgaudit.log"
+      value        = "ddl,role"
+      apply_method = "pending-reboot"
     }
   }
 

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -33,6 +33,23 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
     value        = var.rds_force_ssl
     apply_method = "pending-reboot"
   }
+
+  dynamic "parameter" {
+    for_each = var.add_pgaudit_to_shared_preload_libraries ? [1] : []
+    content {
+      name  = "shared_preload_libraries"
+      value = "pgaudit,pg_stat_statements"
+    }
+  }
+
+  dynamic "parameter" {
+    for_each = var.add_pgaudit_log_parameter ? [1] : []
+    content {
+      name  = "pgaudit.log"
+      value = "ddl,role"
+    }
+  }
+
 }
 
 resource "aws_db_parameter_group" "parameter_group_mysql" {

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -47,7 +47,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
     for_each = var.rds_add_pgaudit_log_parameter ? [1] : []
     content {
       name         = "pgaudit.log"
-      value        = "ddl,role"
+      value        = var.rds_pgaudit_log_values
       apply_method = "pending-reboot"
     }
   }

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -35,7 +35,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
   }
 
   dynamic "parameter" {
-    for_each = var.add_pgaudit_to_shared_preload_libraries ? [1] : []
+    for_each = var.rds_add_pgaudit_to_shared_preload_libraries ? [1] : []
     content {
       name  = "shared_preload_libraries"
       value = "pgaudit,pg_stat_statements"
@@ -43,7 +43,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
   }
 
   dynamic "parameter" {
-    for_each = var.add_pgaudit_log_parameter ? [1] : []
+    for_each = var.rds_add_pgaudit_log_parameter ? [1] : []
     content {
       name  = "pgaudit.log"
       value = "ddl,role"

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -89,13 +89,13 @@ variable "performance_insights_enabled" {
   default = "false"
 }
 
-variable "add_pgaudit_to_shared_preload_libraries" {
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
   default     = false
 }
 
-variable "add_pgaudit_log_parameter" {
+variable "rds_add_pgaudit_log_parameter" {
   description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
   type        = bool
   default     = false

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -104,11 +104,11 @@ variable "rds_add_pgaudit_log_parameter" {
 variable "rds_shared_preload_libraries" {
   description = "List of shared_preload_libraries to load"
   type        = string
-  default     = "pgaudit,pg_stat_statements,pg_tle"
+  default     = "pg_stat_statements"
 }
 
 variable "rds_pgaudit_log_values" {
   description = "List of statements that should be included in pgaudit logs"
   type        = string
-  default     = "ddl,role"
+  default     = "none"
 }

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -100,3 +100,9 @@ variable "rds_add_pgaudit_log_parameter" {
   type        = bool
   default     = false
 }
+
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pgaudit,pg_stat_statements,pg_tle"
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -106,3 +106,9 @@ variable "rds_shared_preload_libraries" {
   type        = string
   default     = "pgaudit,pg_stat_statements,pg_tle"
 }
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "ddl,role"
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -88,3 +88,15 @@ variable "rds_allow_major_version_upgrade" {
 variable "performance_insights_enabled" {
   default = "false"
 }
+
+variable "add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -268,7 +268,8 @@ module "cf" {
   rds_force_ssl                               = var.rds_force_ssl_cf
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_cf
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_cf
-
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_cf
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_cf
 
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -258,14 +258,16 @@ module "cf" {
     var.force_restricted_network == "no" ? module.stack.web_traffic_security_group : module.stack.restricted_web_traffic_security_group,
   ]
 
-  rds_password               = var.cf_rds_password
-  rds_subnet_group           = module.stack.rds_subnet_group
-  rds_security_groups        = [module.stack.rds_postgres_security_group]
-  rds_instance_type          = var.cf_rds_instance_type
-  stack_prefix               = "cf-${var.stack_description}"
-  rds_db_engine_version      = var.rds_db_engine_version_cf
-  rds_parameter_group_family = var.rds_parameter_group_family_cf
-  rds_force_ssl              = var.rds_force_ssl_cf
+  rds_password                                   = var.cf_rds_password
+  rds_subnet_group                               = module.stack.rds_subnet_group
+  rds_security_groups                            = [module.stack.rds_postgres_security_group]
+  rds_instance_type                              = var.cf_rds_instance_type
+  stack_prefix                                   = "cf-${var.stack_description}"
+  rds_db_engine_version                          = var.rds_db_engine_version_cf
+  rds_parameter_group_family                     = var.rds_parameter_group_family_cf
+  rds_force_ssl                                  = var.rds_force_ssl_cf
+  rds_add_pgaudit_to_shared_preload_libraries_cf = var.rds_add_pgaudit_to_shared_preload_libraries
+  rds_add_pgaudit_log_parameter_cf               = var.rds_add_pgaudit_log_parameter
 
 
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -258,16 +258,16 @@ module "cf" {
     var.force_restricted_network == "no" ? module.stack.web_traffic_security_group : module.stack.restricted_web_traffic_security_group,
   ]
 
-  rds_password                                   = var.cf_rds_password
-  rds_subnet_group                               = module.stack.rds_subnet_group
-  rds_security_groups                            = [module.stack.rds_postgres_security_group]
-  rds_instance_type                              = var.cf_rds_instance_type
-  stack_prefix                                   = "cf-${var.stack_description}"
-  rds_db_engine_version                          = var.rds_db_engine_version_cf
-  rds_parameter_group_family                     = var.rds_parameter_group_family_cf
-  rds_force_ssl                                  = var.rds_force_ssl_cf
-  rds_add_pgaudit_to_shared_preload_libraries_cf = var.rds_add_pgaudit_to_shared_preload_libraries
-  rds_add_pgaudit_log_parameter_cf               = var.rds_add_pgaudit_log_parameter
+  rds_password                                = var.cf_rds_password
+  rds_subnet_group                            = module.stack.rds_subnet_group
+  rds_security_groups                         = [module.stack.rds_postgres_security_group]
+  rds_instance_type                           = var.cf_rds_instance_type
+  stack_prefix                                = "cf-${var.stack_description}"
+  rds_db_engine_version                       = var.rds_db_engine_version_cf
+  rds_parameter_group_family                  = var.rds_parameter_group_family_cf
+  rds_force_ssl                               = var.rds_force_ssl_cf
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_cf
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_cf
 
 
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -324,3 +324,15 @@ variable "ecr_stack_name" {
 variable "bosh_blobstore_sse" {
   default = "AES256"
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_cf" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_cf" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -340,9 +340,11 @@ variable "rds_add_pgaudit_log_parameter_cf" {
 variable "rds_shared_preload_libraries_cf" {
   description = "List of shared_preload_libraries to load"
   type        = string
+  default     = "pg_stat_statements"
 }
 
 variable "rds_pgaudit_log_values_cf" {
   description = "List of statements that should be included in pgaudit logs"
   type        = string
+  default     = "none"
 }

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -336,3 +336,13 @@ variable "rds_add_pgaudit_log_parameter_cf" {
   type        = bool
   default     = false
 }
+
+variable "rds_shared_preload_libraries_cf" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+}
+
+variable "rds_pgaudit_log_values_cf" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables and configures the `pgaudit` extension for CF's CCDB RDS instances for development.
- This is to fix a Nessus finding: `3.2 Ensure the PostgreSQL Audit Extension (pgAudit) is enabled`
- The rest of the RDS instances will have this enabled in subsequent PR's, this one serves as a template for the others.
- Part of https://github.com/cloud-gov/private/issues/2423

## Deployment Order

1. Verify the value `shared_preload_libraries` currently has for the parameter group associated with the RDS instance in question, there is drift between v15 and v16 after spot checking a few
2. Set in pipeline.yml for `plan-development`, for `TF_VAR_rds_shared_preload_libraries_cf` it should contain all the values from Step 1 plus `pgaudit` as a comma separated list, order does not matter:

    ```
    TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_cf: true
    TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
    ```
3. Plan, Apply pipeline
4. In AWS Console, reboot the RDS instance so the parameter group is applied and shared libraries are loaded into memory
5. Now set in set `pipeline.yml` so the init-db script adds the `pgaudit` extension to the list of user databases:

    ```
    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
    ```
6. Apply pipeline so init-cf-db job step runs the `CUSTOM_EXTENSIONS` variables, in the output you should see the new extension added to each user database
7. Now that `pgaudit` is loaded as a shared library into memory and the extension enabled in each user database, it can be configured to audit a certain set of transactions by setting the following in `pipeline.yml`:

    ```
    TF_VAR_rds_add_pgaudit_log_parameter_cf: true
    TF_VAR_rds_pgaudit_log_values_cf: "ddl,role"
    ```
8. Plan, Apply pipeline.  You should see the parameter group `pgaudit.log` parameter being configured.
9. In AWS Console, reboot the RDS instance so the parameter group is applied and pgaudit is configured to log `ddl` and `role` changes.
10. Rerun Nessus and verify the 3.2 finding is cleared 


## security considerations
No new passwords leveraged, new logs remain inside of AWS.
