### PR TITLE
Enable pgaudit for cf staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -956,6 +956,10 @@ jobs:
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_rds_force_ssl_cf: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_cf: true
+          TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter_cf: true
+          TF_VAR_rds_pgaudit_log_values_cf: "ddl,role"
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
@@ -1070,6 +1074,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: ccdb uaadb diegodb locketdb policydb silkdb routingdb
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: cf_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_rds_password


### PR DESCRIPTION
## Changes proposed in this pull request:
- True up pipeline, adds pgaudit extension to ccdb for CF staging
- Part of https://github.com/cloud-gov/private/issues/2423
-

## Security considerations
No new passwords or changes to security, adds a new db extensions that Nessus identified as being needed
