### PR TITLE
pgaudit - BOSH Development with deployment instructions

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -700,6 +700,12 @@ jobs:
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
           TF_VAR_rds_force_ssl: 1
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
+          TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
+          TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_rds_force_ssl_cf: 1
@@ -712,6 +718,12 @@ jobs:
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub: true
+          TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
+          TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
+
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_rds_force_ssl_autoscaler: 1
@@ -782,6 +794,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: bosh bosh_uaadb
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: bosh_rds_host_curr
                     TERRAFORM_DB_USERNAME_FIELD: bosh_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: bosh_rds_password
@@ -801,6 +814,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: credhub
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: credhub_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: credhub_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: credhub_rds_password

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -56,6 +56,11 @@ module "rds" {
   rds_security_groups             = [module.rds_network.rds_postgres_security_group]
   rds_parameter_group_family      = var.rds_parameter_group_family
   rds_force_ssl                   = var.rds_force_ssl
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_bosh
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_bosh
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_bosh
 }
 
 module "credhub_rds" {
@@ -76,4 +81,15 @@ module "credhub_rds" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_parameter_group_family      = var.credhub_rds_parameter_group_family
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_bosh_credhub
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_bosh_credhub
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_bosh_credhub
+
 }
+
+
+
+
+

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -133,6 +133,29 @@ variable "rds_multi_az" {
   default = "true"
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
 /*
  * CredHub database variables
  */
@@ -193,4 +216,28 @@ variable "s3_gateway_policy_accounts" {
 variable "cidr_blocks" {
   type    = list(string)
   default = []
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh_credhub" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh_credhub" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh_credhub" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
 }

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -34,6 +34,15 @@ module "base" {
   credhub_rds_db_engine_version      = var.rds_db_engine_version_bosh_credhub
   credhub_rds_parameter_group_family = var.rds_parameter_group_family_bosh_credhub
 
+  rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub = var.rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub
+  rds_add_pgaudit_log_parameter_bosh_credhub               = var.rds_add_pgaudit_log_parameter_bosh_credhub
+  rds_shared_preload_libraries_bosh_credhub                = var.rds_shared_preload_libraries_bosh_credhub
+  rds_pgaudit_log_values_bosh_credhub                      = var.rds_pgaudit_log_values_bosh_credhub
+
+  rds_add_pgaudit_to_shared_preload_libraries_bosh = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
+  rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
+  rds_shared_preload_libraries_bosh                = var.rds_shared_preload_libraries_bosh
+  rds_pgaudit_log_values_bosh                      = var.rds_pgaudit_log_values_bosh
 
   rds_security_groups = [
     module.base.bosh_security_group,

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -185,3 +185,52 @@ variable "rds_db_engine_version_bosh_credhub" {
 variable "rds_parameter_group_family_bosh_credhub" {
   default = "postgres15"
 }
+
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh_credhub" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh_credhub" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh_credhub" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -211,6 +211,15 @@ module "stack" {
   rds_db_engine_version_bosh_credhub      = var.rds_db_engine_version_bosh_credhub
   rds_parameter_group_family_bosh_credhub = var.rds_parameter_group_family_bosh_credhub
 
+  rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub = var.rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub
+  rds_add_pgaudit_log_parameter_bosh_credhub               = var.rds_add_pgaudit_log_parameter_bosh_credhub
+  rds_shared_preload_libraries_bosh_credhub                = var.rds_shared_preload_libraries_bosh_credhub
+  rds_pgaudit_log_values_bosh_credhub                      = var.rds_pgaudit_log_values_bosh_credhub
+
+  rds_add_pgaudit_to_shared_preload_libraries_bosh = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
+  rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
+  rds_shared_preload_libraries_bosh                = var.rds_shared_preload_libraries_bosh
+  rds_pgaudit_log_values_bosh                      = var.rds_pgaudit_log_values_bosh
 
   parent_account_id           = data.aws_arn.parent_role_arn.account
   target_account_id           = data.aws_caller_identity.tooling.account_id

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -36,6 +36,30 @@ variable "rds_force_ssl" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_autoscaler" {
   default = "15.7"
 }
@@ -285,6 +309,30 @@ variable "rds_db_engine_version_bosh_credhub" {
 
 variable "rds_parameter_group_family_bosh_credhub" {
   default = "postgres15"
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh_credhub" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh_credhub" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh_credhub" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
 }
 
 variable "waf_regex_rules" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables and configures the `pgaudit` extension for both RDS instances for development BOSH (director db and credhub).
- This is to fix a Nessus finding: `3.2 Ensure the PostgreSQL Audit Extension (pgAudit) is enabled`
- The rest of the RDS instances will have this enabled in subsequent PR's, this one serves as a template for the others.
- Part of https://github.com/cloud-gov/private/issues/2423

## Deployment Order

1. Verify the value `shared_preload_libraries` currently has for the parameter group associated with the RDS instance in question, there is drift between v15 and v16 after spot checking a few
2. Set in pipeline.yml for `plan-development`, for `TF_VAR_rds_shared_preload_libraries_bosh` and `TF_VAR_rds_shared_preload_libraries_bosh_credhub` it should contain all the values from Step 1 plus `pgaudit` as a comma separated list, order does not matter:

    ```
    TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
    TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
    TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub: true
    TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"

    ```
3. Plan, Apply pipeline
4. In AWS Console, reboot the RDS instance so the parameter group is applied and shared libraries are loaded into memory
5. Now set in set `pipeline.yml` so the init-db script adds the `pgaudit` extension to the list of user databases:

    ```
    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
    ```
6. Apply pipeline so init-bosh-db and init-bosh-credhub-db jobs step runs the `CUSTOM_EXTENSIONS` variables, in the output you should see the new extension added to each user database
7. Now that `pgaudit` is loaded as a shared library into memory and the extension enabled in each user database, it can be configured to audit a certain set of transactions by setting the following in `pipeline.yml`:

    ```
    TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
    TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
    TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
    TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
    ```
8. Plan, Apply pipeline.  You should see the parameter group `pgaudit.log` parameter being configured for both RDS instances
9. In AWS Console, reboot each RDS instance so the parameter group is applied and pgaudit is configured to log `ddl` and `role` changes.

## Security considerations
No new passwords or changes to security, adds a new db extensions that Nessus identified as being needed