### PR TITLE
Update pipeline for pgaudit for bosh in production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1231,12 +1231,24 @@ jobs:
           TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_password: ((production_rds_password))
           TF_VAR_rds_db_size: ((production_rds_db_size))
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
+          TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
+          TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+
           # Enable for database upgrades:
           #TF_VAR_rds_apply_immediately: "true"
           #TF_VAR_rds_allow_major_version_upgrade: "true"
           TF_VAR_credhub_rds_password: ((production_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub: true
+          TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
+          TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
+
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_rds_force_ssl_autoscaler: 1
@@ -1311,6 +1323,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: bosh bosh_uaadb
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: bosh_rds_host_curr
                     TERRAFORM_DB_USERNAME_FIELD: bosh_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: bosh_rds_password
@@ -1330,6 +1343,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: credhub
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: credhub_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: credhub_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: credhub_rds_password


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds and configures pgaudit extension to the BOSH director's two RDS instances in Production
- Already deployed, this trues up the pipeline
- Part of https://github.com/cloud-gov/private/issues/2482

## security considerations
No new passwords or changes to boundary

