### PR TITLE
Update pipeline for pgaudit for bosh in Tooling

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -416,9 +416,18 @@ jobs:
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
           TF_VAR_rds_force_ssl_bosh: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
+          TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
+          TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+
 
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub: true
+          TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
+          TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
 
           TF_VAR_rds_db_engine_version_credhub_staging: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
@@ -468,6 +477,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: bosh bosh_uaadb
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: bosh_rds_host_curr
                 TERRAFORM_DB_USERNAME_FIELD: bosh_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: bosh_rds_password
@@ -487,6 +497,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: credhub
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: credhub_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: credhub_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: credhub_rds_password

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -117,6 +117,17 @@ module "stack" {
   s3_gateway_policy_accounts             = var.s3_gateway_policy_accounts
   credhub_rds_db_engine_version          = var.rds_db_engine_version_bosh_credhub
   credhub_rds_parameter_group_family     = var.rds_parameter_group_family_bosh_credhub
+
+  rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub = var.rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub
+  rds_add_pgaudit_log_parameter_bosh_credhub               = var.rds_add_pgaudit_log_parameter_bosh_credhub
+  rds_shared_preload_libraries_bosh_credhub                = var.rds_shared_preload_libraries_bosh_credhub
+  rds_pgaudit_log_values_bosh_credhub                      = var.rds_pgaudit_log_values_bosh_credhub
+
+  rds_add_pgaudit_to_shared_preload_libraries_bosh = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
+  rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
+  rds_shared_preload_libraries_bosh                = var.rds_shared_preload_libraries_bosh
+  rds_pgaudit_log_values_bosh                      = var.rds_pgaudit_log_values_bosh
+
 }
 
 module "concourse_production" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -49,6 +49,30 @@ variable "rds_force_ssl_bosh" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_credhub_staging" {
   default = "15.5"
 }
@@ -313,6 +337,30 @@ variable "rds_db_engine_version_bosh_credhub" {
 
 variable "rds_parameter_group_family_bosh_credhub" {
   default = "postgres15"
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_bosh_credhub" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_bosh_credhub" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_bosh_credhub" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
 }
 
 variable "aws_lb_listener_ssl_policy" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds and configures pgaudit extension to the BOSH director's two RDS instances in Tooling
- Already deployed, this trues up the pipeline
- Part of https://github.com/cloud-gov/private/issues/2482

## security considerations
No new passwords or changes to boundary