### PR TITLE
Update pipeline for pgaudit for autoscaler

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -738,6 +738,12 @@ jobs:
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_rds_force_ssl_autoscaler: 1
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_autoscaler: true
+          TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_autoscaler: true
+          TF_VAR_rds_pgaudit_log_values_autoscaler: "ddl,role"
+
           TF_VAR_restricted_ingress_web_cidrs: ((development_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((development_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.dev.us-gov-west-1.aws-us-gov.cloud.gov
@@ -867,6 +873,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: autoscaler
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: cf_as_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_as_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_as_rds_password
@@ -1003,6 +1010,12 @@ jobs:
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_rds_force_ssl_autoscaler: 1
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_autoscaler: true
+          TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_autoscaler: true
+          TF_VAR_rds_pgaudit_log_values_autoscaler: "ddl,role"
+
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
           TF_VAR_cf_rds_password: ((staging_cf_rds_password))
@@ -1134,6 +1147,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: autoscaler
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: cf_as_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_as_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_as_rds_password
@@ -1263,6 +1277,12 @@ jobs:
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_rds_force_ssl_autoscaler: 1
+
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_autoscaler: true
+          TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_autoscaler: true
+          TF_VAR_rds_pgaudit_log_values_autoscaler: "ddl,role"
+
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))
@@ -1395,6 +1415,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: autoscaler
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: cf_as_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_as_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_as_rds_password

--- a/terraform/modules/autoscaler/database.tf
+++ b/terraform/modules/autoscaler/database.tf
@@ -15,4 +15,9 @@ module "cf_as_database" {
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
   rds_force_ssl                   = var.rds_force_ssl
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_autoscaler
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_autoscaler
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_autoscaler
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_autoscaler
 }

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -51,3 +51,27 @@ variable "rds_allow_major_version_upgrade" {
 variable "rds_force_ssl" {
   default = 1
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_autoscaler" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_autoscaler" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_autoscaler" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_autoscaler" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -334,6 +334,11 @@ module "autoscaler" {
   rds_parameter_group_family      = var.rds_parameter_group_family_autoscaler
   rds_force_ssl                   = var.rds_force_ssl_autoscaler
 
+  rds_add_pgaudit_to_shared_preload_libraries_autoscaler = var.rds_add_pgaudit_to_shared_preload_libraries_autoscaler
+  rds_add_pgaudit_log_parameter_autoscaler               = var.rds_add_pgaudit_log_parameter_autoscaler
+  rds_shared_preload_libraries_autoscaler                = var.rds_shared_preload_libraries_autoscaler
+  rds_pgaudit_log_values_autoscaler                      = var.rds_pgaudit_log_values_autoscaler
+
 }
 
 resource "random_string" "autoscaler_rds_password" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -72,6 +72,30 @@ variable "rds_force_ssl_autoscaler" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_autoscaler" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_autoscaler" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_autoscaler" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_autoscaler" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_cf" {
   default = "16.3"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds and configures pgaudit extension to the autoscaler RDS instances in Development, Staging and Production
- Already deployed, this trues up the pipeline
- Part of https://github.com/cloud-gov/private/issues/2481

## security considerations
No new passwords or changes to boundary
