### PR TITLE
Update pipeline for pgaudit for concourse and concourse credhub in staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -432,6 +432,10 @@ jobs:
           TF_VAR_rds_db_engine_version_credhub_staging: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
           TF_VAR_rds_force_ssl_credhub_staging: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_credhub_staging: true
+          TF_VAR_rds_shared_preload_libraries_credhub_staging: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_credhub_staging: true
+          TF_VAR_rds_pgaudit_log_values_credhub_staging: "ddl,role" 
 
           TF_VAR_rds_db_engine_version_credhub_production: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
@@ -440,6 +444,10 @@ jobs:
           TF_VAR_rds_db_engine_version_concourse_staging: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
           TF_VAR_rds_force_ssl_concourse_staging: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_concourse_staging: true
+          TF_VAR_rds_shared_preload_libraries_concourse_staging: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_concourse_staging: true
+          TF_VAR_rds_pgaudit_log_values_concourse_staging: "ddl,role"
 
           TF_VAR_rds_db_engine_version_concourse_production: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
@@ -517,6 +525,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: credhub
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: staging_credhub_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: staging_credhub_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: staging_credhub_rds_password
@@ -555,6 +564,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: atc
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: staging_concourse_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: staging_concourse_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: staging_concourse_rds_password

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -20,4 +20,10 @@ module "rds_96" {
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
   performance_insights_enabled    = var.performance_insights_enabled
   rds_force_ssl                   = var.rds_force_ssl
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -92,3 +92,27 @@ variable "performance_insights_enabled" {
 variable "rds_force_ssl" {
   default = 1
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/terraform/modules/credhub/rds.tf
+++ b/terraform/modules/credhub/rds.tf
@@ -19,4 +19,10 @@ module "rds_96" {
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
   rds_force_ssl                   = var.rds_force_ssl
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+
 }

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -96,3 +96,27 @@ variable "hosts" {
 variable "rds_force_ssl" {
   default = 1
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -156,6 +156,11 @@ module "concourse_production" {
   rds_final_snapshot_identifier   = "final-snapshot-atc-tooling-production"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.concourse_production_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_concourse_production
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_concourse_production
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_concourse_production
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_concourse_production
 }
 
 module "concourse_staging" {
@@ -183,6 +188,11 @@ module "concourse_staging" {
   rds_final_snapshot_identifier   = "final-snapshot-atc-tooling-staging"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.concourse_staging_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_concourse_staging
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_concourse_staging
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_concourse_staging
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_concourse_staging
 }
 
 module "credhub_production" {
@@ -209,6 +219,11 @@ module "credhub_production" {
   rds_final_snapshot_identifier   = "final-snapshot-credhub-tooling-production"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.credhub_production_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_credhub_production
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_credhub_production
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_credhub_production
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_credhub_production
 }
 
 module "credhub_staging" {
@@ -238,6 +253,11 @@ module "credhub_staging" {
   rds_final_snapshot_identifier   = "final-snapshot-credhub-tooling-staging"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.credhub_staging_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_credhub_staging
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_credhub_staging
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_credhub_staging
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_credhub_staging
 }
 
 module "defectdojo_development" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -85,6 +85,30 @@ variable "rds_force_ssl_credhub_staging" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_credhub_staging" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_credhub_staging" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_credhub_staging" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_credhub_staging" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_credhub_production" {
   default = "15.5"
 }
@@ -95,6 +119,30 @@ variable "rds_parameter_group_family_credhub_production" {
 
 variable "rds_force_ssl_credhub_production" {
   default = 1
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_credhub_production" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_credhub_production" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_credhub_production" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_credhub_production" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
 }
 
 variable "rds_db_engine_version_concourse_staging" {
@@ -109,6 +157,30 @@ variable "rds_force_ssl_concourse_staging" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_concourse_staging" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_concourse_staging" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_concourse_staging" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_concourse_staging" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_concourse_production" {
   default = "15.5"
 }
@@ -119,6 +191,30 @@ variable "rds_parameter_group_family_concourse_production" {
 
 variable "rds_force_ssl_concourse_production" {
   default = 1
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_concourse_production" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_concourse_production" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_concourse_production" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_concourse_production" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
 }
 
 variable "rds_db_engine_version_opsuaa" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds and configures pgaudit extension to the Staging Concourse and Staging Concourse Credhub RDS instances
- Already deployed, this trues up the pipeline
- Part of https://github.com/cloud-gov/private/issues/2483

## security considerations
No new passwords or changes to boundary