### PR TITLE
Update pipeline for pgaudit for concourse and concourse credhub in production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -421,7 +421,6 @@ jobs:
           TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
           TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
 
-
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub: true
@@ -440,6 +439,10 @@ jobs:
           TF_VAR_rds_db_engine_version_credhub_production: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
           TF_VAR_rds_force_ssl_credhub_production: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_credhub_production: true
+          TF_VAR_rds_shared_preload_libraries_credhub_production: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_credhub_production: true
+          TF_VAR_rds_pgaudit_log_values_credhub_production: "ddl,role"
 
           TF_VAR_rds_db_engine_version_concourse_staging: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
@@ -452,6 +455,10 @@ jobs:
           TF_VAR_rds_db_engine_version_concourse_production: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
           TF_VAR_rds_force_ssl_concourse_production: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_concourse_production: true
+          TF_VAR_rds_shared_preload_libraries_concourse_production: "pgaudit,pg_stat_statements"
+          TF_VAR_rds_add_pgaudit_log_parameter_concourse_production: true
+          TF_VAR_rds_pgaudit_log_values_concourse_production: "ddl,role"
 
           TF_VAR_rds_db_engine_version_opsuaa: "16.8"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
@@ -545,6 +552,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: credhub
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: production_credhub_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: production_credhub_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: production_credhub_rds_password
@@ -584,6 +592,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: atc
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: production_concourse_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: production_concourse_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: production_concourse_rds_password


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds and configures pgaudit extension to the Production Concourse and Production Concourse Credhub RDS instances
- Already deployed, this trues up the pipeline
- Part of https://github.com/cloud-gov/private/issues/2483

## security considerations
No new passwords or changes to boundary