### PR TITLE
Add `pgaudit` to RDS - OpsUAA, DefectDojo, Domains Broker (old)

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -404,14 +404,27 @@ jobs:
           TF_VAR_rds_db_engine_version_defectdojo_development: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_development: "postgres16"
           TF_VAR_rds_force_ssl_defectdojo_development: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_defectdojo_development: true
+          TF_VAR_rds_shared_preload_libraries_defectdojo_development: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_development: true
+          TF_VAR_rds_pgaudit_log_values_defectdojo_development: "ddl,role"
+
 
           TF_VAR_rds_db_engine_version_defectdojo_staging: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_staging: "postgres16"
           TF_VAR_rds_force_ssl_defectdojo_staging: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_defectdojo_staging: true
+          TF_VAR_rds_shared_preload_libraries_defectdojo_staging: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_staging: true
+          TF_VAR_rds_pgaudit_log_values_defectdojo_staging: "ddl,role"
 
           TF_VAR_rds_db_engine_version_defectdojo_production: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_production: "postgres16"
           TF_VAR_rds_force_ssl_defectdojo_production: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_defectdojo_production: true
+          TF_VAR_rds_shared_preload_libraries_defectdojo_production: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_production: true
+          TF_VAR_rds_pgaudit_log_values_defectdojo_production: "ddl,role"
 
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
@@ -463,6 +476,11 @@ jobs:
           TF_VAR_rds_db_engine_version_opsuaa: "16.8"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
           TF_VAR_rds_force_ssl_opsuaa: 1
+          TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_opsuaa: true
+          TF_VAR_rds_shared_preload_libraries_opsuaa: "pgaudit,pg_stat_statements,pg_tle"
+          TF_VAR_rds_add_pgaudit_log_parameter_opsuaa: true
+          TF_VAR_rds_pgaudit_log_values_opsuaa: "ddl,role"
+
 
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
@@ -612,6 +630,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: opsuaa
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: opsuaa_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: opsuaa_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: opsuaa_rds_password
@@ -631,6 +650,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: dojo
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: development_defectdojo_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: development_defectdojo_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: development_defectdojo_rds_password
@@ -650,6 +670,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: dojo
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: staging_defectdojo_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: staging_defectdojo_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: staging_defectdojo_rds_password
@@ -669,6 +690,7 @@ jobs:
               params:
                 STATE_FILE_PATH: terraform-state/terraform.tfstate
                 DATABASES: dojo
+                CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                 TERRAFORM_DB_HOST_FIELD: production_defectdojo_rds_host
                 TERRAFORM_DB_USERNAME_FIELD: production_defectdojo_rds_username
                 TERRAFORM_DB_PASSWORD_FIELD: production_defectdojo_rds_password
@@ -913,6 +935,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: domains_broker
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: domains_broker_rds_address
                     TERRAFORM_DB_USERNAME_FIELD: domains_broker_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: domains_broker_rds_password
@@ -1187,6 +1210,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: domains_broker
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: domains_broker_rds_address
                     TERRAFORM_DB_USERNAME_FIELD: domains_broker_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: domains_broker_rds_password
@@ -1455,6 +1479,7 @@ jobs:
                   params:
                     STATE_FILE_PATH: terraform-state/terraform.tfstate
                     DATABASES: domains_broker
+                    CUSTOM_EXTENSIONS: citext uuid-ossp pgcrypto pg_stat_statements pgaudit
                     TERRAFORM_DB_HOST_FIELD: domains_broker_rds_address
                     TERRAFORM_DB_USERNAME_FIELD: domains_broker_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: domains_broker_rds_password

--- a/terraform/modules/defect_dojo/rds.tf
+++ b/terraform/modules/defect_dojo/rds.tf
@@ -19,4 +19,9 @@ module "rds_96" {
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
   rds_force_ssl                   = var.rds_force_ssl
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
 }

--- a/terraform/modules/defect_dojo/variables.tf
+++ b/terraform/modules/defect_dojo/variables.tf
@@ -94,3 +94,27 @@ variable "hosts" {
 variable "rds_force_ssl" {
   default = 1
 }
+
+variable "rds_add_pgaudit_to_shared_preload_libraries" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -17,6 +17,12 @@ module "opsuaa_db" {
   rds_force_ssl                   = var.rds_force_ssl_opsuaa
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_opsuaa
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_opsuaa
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_opsuaa
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_opsuaa
+
 }
 
 output "opsuaa_rds_url" {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -287,6 +287,12 @@ module "defectdojo_development" {
   rds_final_snapshot_identifier   = "final-snapshot-defectdojo-tooling-development"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.defectdojo_development_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_defectdojo_development
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_defectdojo_development
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_defectdojo_development
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_defectdojo_development
+
 }
 
 module "defectdojo_staging" {
@@ -316,6 +322,11 @@ module "defectdojo_staging" {
   rds_final_snapshot_identifier   = "final-snapshot-defectdojo-tooling-staging"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.defectdojo_staging_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_defectdojo_staging
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_defectdojo_staging
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_defectdojo_staging
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_defectdojo_staging
 }
 
 module "defectdojo_production" {
@@ -345,6 +356,11 @@ module "defectdojo_production" {
   rds_final_snapshot_identifier   = "final-snapshot-defectdojo-tooling-production"
   listener_arn                    = aws_lb_listener.main.arn
   hosts                           = var.defectdojo_production_hosts
+
+  rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_defectdojo_production
+  rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_defectdojo_production
+  rds_shared_preload_libraries                = var.rds_shared_preload_libraries_defectdojo_production
+  rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_defectdojo_production
 }
 
 module "monitoring_production" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -500,6 +500,30 @@ variable "rds_force_ssl_defectdojo_development" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_defectdojo_development" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_defectdojo_development" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_defectdojo_development" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_defectdojo_development" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_defectdojo_staging" {
   default = "16.3"
 }
@@ -512,6 +536,30 @@ variable "rds_force_ssl_defectdojo_staging" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_defectdojo_staging" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_defectdojo_staging" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_defectdojo_staging" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_defectdojo_staging" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "rds_db_engine_version_defectdojo_production" {
   default = "16.3"
 }
@@ -522,4 +570,28 @@ variable "rds_parameter_group_family_defectdojo_production" {
 
 variable "rds_force_ssl_defectdojo_production" {
   default = 1
+}
+
+variable "rds_add_pgaudit_to_shared_preload_libraries_defectdojo_production" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_defectdojo_production" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_defectdojo_production" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_defectdojo_production" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -229,6 +229,30 @@ variable "rds_force_ssl_opsuaa" {
   default = 1
 }
 
+variable "rds_add_pgaudit_to_shared_preload_libraries_opsuaa" {
+  description = "Whether to enable pgaudit in shared_preload_libraries"
+  type        = bool
+  default     = false
+}
+
+variable "rds_add_pgaudit_log_parameter_opsuaa" {
+  description = "Whether to configure the pgaudit.log parameter.  Requires add_pgaudit_to_shared_preload_libraries to apply the setting."
+  type        = bool
+  default     = false
+}
+
+variable "rds_shared_preload_libraries_opsuaa" {
+  description = "List of shared_preload_libraries to load"
+  type        = string
+  default     = "pg_stat_statements"
+}
+
+variable "rds_pgaudit_log_values_opsuaa" {
+  description = "List of statements that should be included in pgaudit logs"
+  type        = string
+  default     = "none"
+}
+
 variable "remote_state_bucket" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds and configures pgaudit extension to the DefectDojo's RDS instances in development, staging and production in tooling
- Adds and configures pgaudit extension to the OpsUAA's RDS instance in tooling
- Configures pgaudit extension to the Domain Broker's RDS instances in development, staging and production
- Already deployed, this trues up the pipeline
- Part of https://github.com/cloud-gov/private/issues/2484

## security considerations
No new passwords or changes to boundary