### PR TITLE
Nessus RDS finding: 7.2 Ensure logging of replication commands is configured - CCDB

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -765,6 +765,9 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_cf: true
           TF_VAR_rds_pgaudit_log_values_cf: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_cf: true
+
+
           TF_VAR_cf_rds_password: ((development_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((development_cf_as_rds_instance_type))
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -19,4 +19,5 @@ module "cf_database_96" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -291,3 +291,9 @@ variable "rds_pgaudit_log_values" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -52,6 +52,14 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
     }
   }
 
+  dynamic "parameter" {
+    for_each = var.rds_add_log_replication_commands ? [1] : []
+    content {
+      name         = "log_replication_commands"
+      value        = 1
+      apply_method = "pending-reboot"
+    }
+  }
 }
 
 resource "aws_db_parameter_group" "parameter_group_mysql" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -112,3 +112,9 @@ variable "rds_pgaudit_log_values" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -279,6 +279,7 @@ module "cf" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_cf
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_cf
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_cf
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_cf
 
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -420,3 +420,9 @@ variable "rds_pgaudit_log_values_cf" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands_cf" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables logging of replication commands via the parameter group option `log_replication_commands`, when enabled it will log when a replication slot is used.
- Part of https://github.com/cloud-gov/private/issues/2425
-

## security considerations
Enhances logging of replication slots for security
