### PR TITLE
Nessus RDS finding: 7.2 Ensure logging of replication commands is configured - CCDB staging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1043,6 +1043,8 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_cf: true
           TF_VAR_rds_pgaudit_log_values_cf: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_cf: true
+
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables logging of replication commands via the parameter group option `log_replication_commands`, when enabled it will log when a replication slot is used.
- Applies change to staging environment
- Part of https://github.com/cloud-gov/private/issues/2425
-

## security considerations
Enhances logging of replication slots for security
