### PR TITLE
Nessus RDS finding: 7.2 Ensure logging of replication commands is configured - All

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -757,6 +757,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
           TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh: true
 
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"

--- a/terraform/modules/autoscaler/database.tf
+++ b/terraform/modules/autoscaler/database.tf
@@ -20,4 +20,5 @@ module "cf_as_database" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_autoscaler
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_autoscaler
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_autoscaler
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_autoscaler
 }

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -75,3 +75,9 @@ variable "rds_pgaudit_log_values_autoscaler" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands_autoscaler" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -25,5 +25,6 @@ module "rds_96" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands
 
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -116,3 +116,9 @@ variable "rds_pgaudit_log_values" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/credhub/rds.tf
+++ b/terraform/modules/credhub/rds.tf
@@ -24,5 +24,6 @@ module "rds_96" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands
 
 }

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -120,3 +120,9 @@ variable "rds_pgaudit_log_values" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/defect_dojo/rds.tf
+++ b/terraform/modules/defect_dojo/rds.tf
@@ -24,4 +24,5 @@ module "rds_96" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands
 }

--- a/terraform/modules/defect_dojo/variables.tf
+++ b/terraform/modules/defect_dojo/variables.tf
@@ -118,3 +118,9 @@ variable "rds_pgaudit_log_values" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -88,6 +88,7 @@ module "credhub_rds" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_bosh_credhub
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_bosh_credhub
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_bosh_credhub
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_credhub
 
 }
 

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -61,6 +61,8 @@ module "rds" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_bosh
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_bosh
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_bosh
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_bosh
+
 }
 
 module "credhub_rds" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -248,3 +248,9 @@ variable "rds_pgaudit_log_values_bosh_credhub" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands_credhub" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -156,6 +156,13 @@ variable "rds_pgaudit_log_values_bosh" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands_bosh" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 /*
  * CredHub database variables
  */

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -38,6 +38,7 @@ module "base" {
   rds_add_pgaudit_log_parameter_bosh_credhub               = var.rds_add_pgaudit_log_parameter_bosh_credhub
   rds_shared_preload_libraries_bosh_credhub                = var.rds_shared_preload_libraries_bosh_credhub
   rds_pgaudit_log_values_bosh_credhub                      = var.rds_pgaudit_log_values_bosh_credhub
+  rds_add_log_replication_commands_credhub                 = var.rds_add_log_replication_commands_credhub
 
   rds_add_pgaudit_to_shared_preload_libraries_bosh = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
   rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -43,6 +43,8 @@ module "base" {
   rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
   rds_shared_preload_libraries_bosh                = var.rds_shared_preload_libraries_bosh
   rds_pgaudit_log_values_bosh                      = var.rds_pgaudit_log_values_bosh
+  rds_add_log_replication_commands_bosh            = var.rds_add_log_replication_commands_bosh
+
 
   rds_security_groups = [
     module.base.bosh_security_group,

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -240,3 +240,9 @@ variable "rds_pgaudit_log_values_bosh_credhub" {
   type        = string
   default     = "none"
 }
+
+variable "rds_add_log_replication_commands_credhub" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -211,6 +211,12 @@ variable "rds_pgaudit_log_values_bosh" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_bosh" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_add_pgaudit_to_shared_preload_libraries_bosh_credhub" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -215,6 +215,7 @@ module "stack" {
   rds_add_pgaudit_log_parameter_bosh_credhub               = var.rds_add_pgaudit_log_parameter_bosh_credhub
   rds_shared_preload_libraries_bosh_credhub                = var.rds_shared_preload_libraries_bosh_credhub
   rds_pgaudit_log_values_bosh_credhub                      = var.rds_pgaudit_log_values_bosh_credhub
+  rds_add_log_replication_commands_credhub                 = var.rds_add_log_replication_commands_credhub
 
   rds_add_pgaudit_to_shared_preload_libraries_bosh = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
   rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
@@ -340,6 +341,8 @@ module "autoscaler" {
   rds_add_pgaudit_log_parameter_autoscaler               = var.rds_add_pgaudit_log_parameter_autoscaler
   rds_shared_preload_libraries_autoscaler                = var.rds_shared_preload_libraries_autoscaler
   rds_pgaudit_log_values_autoscaler                      = var.rds_pgaudit_log_values_autoscaler
+  rds_add_log_replication_commands_autoscaler            = var.rds_add_log_replication_commands_autoscaler
+
 
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -220,6 +220,7 @@ module "stack" {
   rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
   rds_shared_preload_libraries_bosh                = var.rds_shared_preload_libraries_bosh
   rds_pgaudit_log_values_bosh                      = var.rds_pgaudit_log_values_bosh
+  rds_add_log_replication_commands_bosh            = var.rds_add_log_replication_commands_bosh
 
   parent_account_id           = data.aws_arn.parent_role_arn.account
   target_account_id           = data.aws_caller_identity.tooling.account_id

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -102,6 +102,12 @@ variable "rds_pgaudit_log_values_autoscaler" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_autoscaler" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_cf" {
   default = "16.3"
 }
@@ -365,6 +371,11 @@ variable "rds_pgaudit_log_values_bosh_credhub" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_credhub" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
 variable "waf_regex_rules" {
   type = list(object({
     # path_regex is matched against the uri path of a request

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -60,6 +60,12 @@ variable "rds_pgaudit_log_values_bosh" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_bosh" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_autoscaler" {
   default = "15.7"
 }

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -122,11 +122,14 @@ module "stack" {
   rds_add_pgaudit_log_parameter_bosh_credhub               = var.rds_add_pgaudit_log_parameter_bosh_credhub
   rds_shared_preload_libraries_bosh_credhub                = var.rds_shared_preload_libraries_bosh_credhub
   rds_pgaudit_log_values_bosh_credhub                      = var.rds_pgaudit_log_values_bosh_credhub
+  rds_add_log_replication_commands_credhub                 = var.rds_add_log_replication_commands_credhub
+
 
   rds_add_pgaudit_to_shared_preload_libraries_bosh = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
   rds_add_pgaudit_log_parameter_bosh               = var.rds_add_pgaudit_log_parameter_bosh
   rds_shared_preload_libraries_bosh                = var.rds_shared_preload_libraries_bosh
   rds_pgaudit_log_values_bosh                      = var.rds_pgaudit_log_values_bosh
+  rds_add_log_replication_commands_bosh            = var.rds_add_log_replication_commands_bosh
 
 }
 
@@ -161,6 +164,7 @@ module "concourse_production" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_concourse_production
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_concourse_production
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_concourse_production
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_concourse_production
 }
 
 module "concourse_staging" {
@@ -193,6 +197,7 @@ module "concourse_staging" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_concourse_staging
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_concourse_staging
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_concourse_staging
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_concourse_production
 }
 
 module "credhub_production" {
@@ -224,6 +229,7 @@ module "credhub_production" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_credhub_production
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_credhub_production
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_credhub_production
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_credhub_production
 }
 
 module "credhub_staging" {
@@ -258,6 +264,8 @@ module "credhub_staging" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_credhub_staging
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_credhub_staging
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_credhub_staging
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_credhub_staging
+
 }
 
 module "defectdojo_development" {
@@ -292,6 +300,7 @@ module "defectdojo_development" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_defectdojo_development
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_defectdojo_development
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_defectdojo_development
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_defectdojo_development
 
 }
 
@@ -327,6 +336,7 @@ module "defectdojo_staging" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_defectdojo_staging
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_defectdojo_staging
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_defectdojo_staging
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_defectdojo_staging
 }
 
 module "defectdojo_production" {
@@ -361,6 +371,7 @@ module "defectdojo_production" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_defectdojo_production
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_defectdojo_production
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_defectdojo_production
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_defectdojo_production
 }
 
 module "monitoring_production" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -73,6 +73,12 @@ variable "rds_pgaudit_log_values_bosh" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_bosh" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_credhub_staging" {
   default = "15.5"
 }
@@ -107,6 +113,12 @@ variable "rds_pgaudit_log_values_credhub_staging" {
   description = "List of statements that should be included in pgaudit logs"
   type        = string
   default     = "none"
+}
+
+variable "rds_add_log_replication_commands_credhub_staging" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
 }
 
 variable "rds_db_engine_version_credhub_production" {
@@ -145,6 +157,12 @@ variable "rds_pgaudit_log_values_credhub_production" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_credhub_production" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_concourse_staging" {
   default = "15.5"
 }
@@ -181,6 +199,12 @@ variable "rds_pgaudit_log_values_concourse_staging" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_concourse_staging" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_concourse_production" {
   default = "15.5"
 }
@@ -215,6 +239,12 @@ variable "rds_pgaudit_log_values_concourse_production" {
   description = "List of statements that should be included in pgaudit logs"
   type        = string
   default     = "none"
+}
+
+variable "rds_add_log_replication_commands_concourse_production" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
 }
 
 variable "rds_db_engine_version_opsuaa" {
@@ -483,6 +513,12 @@ variable "rds_pgaudit_log_values_bosh_credhub" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_credhub" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "aws_lb_listener_ssl_policy" {
   type    = string
   default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
@@ -524,6 +560,12 @@ variable "rds_pgaudit_log_values_defectdojo_development" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_defectdojo_development" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_defectdojo_staging" {
   default = "16.3"
 }
@@ -560,6 +602,12 @@ variable "rds_pgaudit_log_values_defectdojo_staging" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_defectdojo_staging" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "rds_db_engine_version_defectdojo_production" {
   default = "16.3"
 }
@@ -594,4 +642,10 @@ variable "rds_pgaudit_log_values_defectdojo_production" {
   description = "List of statements that should be included in pgaudit logs"
   type        = string
   default     = "none"
+}
+
+variable "rds_add_log_replication_commands_defectdojo_production" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds default configurations to all RDS instances maintained by this repo, will be activated one at a time via TF_VAR_ variables in pipeline.yml, BOSH development is wired up in this PR as an example
- Part of https://github.com/cloud-gov/private/issues/2425
-

## security considerations
Adds the option to configure a new parameter group item to resolve a nessus item
