### PR TITLE
Nessus RDS finding: 7.2 Ensure logging of replication commands is configured - All tooling, production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -408,6 +408,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_defectdojo_development: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_development: true
           TF_VAR_rds_pgaudit_log_values_defectdojo_development: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_defectdojo_development: true
 
 
           TF_VAR_rds_db_engine_version_defectdojo_staging: "16.8"
@@ -417,6 +418,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_defectdojo_staging: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_staging: true
           TF_VAR_rds_pgaudit_log_values_defectdojo_staging: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_defectdojo_staging: true
 
           TF_VAR_rds_db_engine_version_defectdojo_production: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_production: "postgres16"
@@ -425,6 +427,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_defectdojo_production: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_production: true
           TF_VAR_rds_pgaudit_log_values_defectdojo_production: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_defectdojo_production: true
 
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
@@ -433,6 +436,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
           TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh: true
 
           TF_VAR_rds_db_engine_version_bosh_credhub: "15.12"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
@@ -440,6 +444,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
           TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh_credhub: true
 
           TF_VAR_rds_db_engine_version_credhub_staging: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
@@ -448,6 +453,8 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_credhub_staging: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_credhub_staging: true
           TF_VAR_rds_pgaudit_log_values_credhub_staging: "ddl,role" 
+          TF_VAR_rds_add_log_replication_commands_credhub_staging: true
+
 
           TF_VAR_rds_db_engine_version_credhub_production: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
@@ -456,6 +463,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_credhub_production: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_credhub_production: true
           TF_VAR_rds_pgaudit_log_values_credhub_production: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_credhub_production: true
 
           TF_VAR_rds_db_engine_version_concourse_staging: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
@@ -464,6 +472,8 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_concourse_staging: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_concourse_staging: true
           TF_VAR_rds_pgaudit_log_values_concourse_staging: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_concourse_staging: true
+
 
           TF_VAR_rds_db_engine_version_concourse_production: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
@@ -472,6 +482,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_concourse_production: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_concourse_production: true
           TF_VAR_rds_pgaudit_log_values_concourse_production: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_concourse_production: true
 
           TF_VAR_rds_db_engine_version_opsuaa: "16.8"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
@@ -779,10 +790,13 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
           TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh_credhub: true
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
           TF_VAR_rds_force_ssl_autoscaler: 1
+          TF_VAR_rds_add_log_replication_commands_autoscaler: true
+
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_autoscaler: true
           TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
@@ -1036,6 +1050,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
           TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh: true
 
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
@@ -1054,6 +1069,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
           TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh_credhub: true
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
@@ -1063,6 +1079,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_autoscaler: true
           TF_VAR_rds_pgaudit_log_values_autoscaler: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_autoscaler: true
 
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
@@ -1310,6 +1327,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
           TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh: true
 
           # Enable for database upgrades:
           #TF_VAR_rds_apply_immediately: "true"
@@ -1322,6 +1340,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_bosh_credhub: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh_credhub: true
           TF_VAR_rds_pgaudit_log_values_bosh_credhub: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_bosh_credhub: true
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
@@ -1331,6 +1350,7 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_autoscaler: true
           TF_VAR_rds_pgaudit_log_values_autoscaler: "ddl,role"
+          TF_VAR_rds_add_log_replication_commands_autoscaler: true
 
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
@@ -1339,6 +1359,8 @@ jobs:
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_rds_force_ssl_cf: 1
+          TF_VAR_rds_add_log_replication_commands_cf: true
+
           TF_VAR_restricted_ingress_web_cidrs: ((production_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -22,6 +22,7 @@ module "opsuaa_db" {
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_opsuaa
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_opsuaa
   rds_pgaudit_log_values                      = var.rds_pgaudit_log_values_opsuaa
+  rds_add_log_replication_commands            = var.rds_add_log_replication_commands_opsuaa
 
 }
 

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -283,6 +283,12 @@ variable "rds_pgaudit_log_values_opsuaa" {
   default     = "none"
 }
 
+variable "rds_add_log_replication_commands_opsuaa" {
+  description = "Whether to enable the log_replication_commands parameter."
+  type        = bool
+  default     = false
+}
+
 variable "remote_state_bucket" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add support to configure opsuaa
- Pipeline changes for bosh (tooling, prod) bosh credhub (tooling, prod), concourse credhub stating, concourse credhub production, concourse staging, concourse production, defect dojo (dev, stage, prod), autoscaler (stage, prod)
-

## security considerations
Configures parameter group option that Nessus identified
