### PR TITLE
Fix invalid value for final_snapshot_identifier in AWS

### DIFF
--- a/terraform/modules/mysql_stig/db/variables.tf
+++ b/terraform/modules/mysql_stig/db/variables.tf
@@ -17,7 +17,7 @@ variable "rds_db_size" {
 
 variable "rds_db_name" {
   type    = string
-  default = "mysql_stig"
+  default = "mysql-stig"
 }
 
 variable "rds_db_engine" {


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- AWS hates `_` in DB names: `Error: invalid value for final_snapshot_identifier (must only contain alphanumeric characters and hyphens)`
-

## security considerations
Safe, as long as the hyphen isn't treated as a minus sign someplace
