### PR TITLE
Investigate Nessus RDS finding: 3.1.22 Ensure 'log_error_verbosity' is set correctly

### DIFF
--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -60,6 +60,12 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
       apply_method = "pending-reboot"
     }
   }
+
+  parameter {
+    name  = "log_error_verbosity"
+    value = "verbose"
+  }
+
 }
 
 resource "aws_db_parameter_group" "parameter_group_mysql" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a parameter group configuration for `log_error_verbosity` for a Nessus finding
- The parameter group configuration is `dynamic` so it doesn't require a reboot to take effect, therefore not creating feature flags for enablement, will roll this to dev, stage, tooling, prod
- Part of https://github.com/cloud-gov/private/issues/2414
-

## security considerations
Adds a configuration desired by Nessus
