### PR TITLE
Add ECR repos to support hardening the cflinuxfs4 stack

### DIFF
--- a/terraform/stacks/ecr/variables.tf
+++ b/terraform/stacks/ecr/variables.tf
@@ -12,10 +12,10 @@ variable "repositories" {
     "bosh-io-stemcell-resource",
     "cf-cli-resource",
     "cf-resource",
-    "cflinuxfs4-hardened",
-    "cflinuxfs4-hardened-candidate",
+    "cflinuxfs4-hardened",           # hardened stack passed cf-acceptance tests
+    "cflinuxfs4-hardened-candidate", # hardened stack not yet passed cf-acceptance tests
     "cloud-service-broker",
-    "cloudfoundry-cflinuxfs4",
+    "cloudfoundry-cflinuxfs4", # current stack in CF
     "concourse-http-jq-resource",
     "concourse-task",
     "cg-csb", # prefixed to avoid collision with the 'csb' pipeline in Concourse.

--- a/terraform/stacks/ecr/variables.tf
+++ b/terraform/stacks/ecr/variables.tf
@@ -13,7 +13,7 @@ variable "repositories" {
     "cf-cli-resource",
     "cf-resource",
     "cflinuxfs4-hardened",
-    "cflinuxfs4-hardened-candiate",
+    "cflinuxfs4-hardened-candidate",
     "cloud-service-broker",
     "cloudfoundry-cflinuxfs4",
     "concourse-http-jq-resource",

--- a/terraform/stacks/ecr/variables.tf
+++ b/terraform/stacks/ecr/variables.tf
@@ -12,7 +12,10 @@ variable "repositories" {
     "bosh-io-stemcell-resource",
     "cf-cli-resource",
     "cf-resource",
+    "cflinuxfs4-hardened",
+    "cflinuxfs4-hardened-candiate",
     "cloud-service-broker",
+    "cloudfoundry-cflinuxfs4",
     "concourse-http-jq-resource",
     "concourse-task",
     "cg-csb", # prefixed to avoid collision with the 'csb' pipeline in Concourse.


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add ECR repos to support hardening the cflinuxfs4 stack

Three repos are needed: 
1.  `cloudfoundry-cflinuxfs4`: The current stack image from the upstream maintainers, copied from Docker hub.
2. `cflinuxfs4-hardened-candidate`: The hardened image that has not yet passed cf-acceptance tests.
3. `cflinuxfs4-hardened`: The hardened image that has passed cf-acceptance tests. 

More info: https://github.com/cloud-gov/hardened-stack/tree/pipeline?tab=readme-ov-file#hardened-stack

## security considerations

We are copying the `cflinuxfs4` image from docker hub to `cloudfoundry-cflinuxfs4`. However, this is the same stack we currently deploy to production so it should be ok. We are following the pattern of: https://github.com/cloud-gov/ubuntu-mirror.
