### PR TITLE
add permission for AWS broker to create RDS read replicas

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.tf
@@ -13,7 +13,8 @@ data "aws_iam_policy_document" "aws_broker_policy" {
       "rds:DeleteDBParameterGroup",
       "rds:DescribeDBParameters",
       "rds:DescribeDBSnapshots",
-      "rds:DeleteDBSnapshot"
+      "rds:DeleteDBSnapshot",
+      "rds:CreateDBInstanceReadReplica"
     ]
 
     resources = [


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/aws-broker/issues/303

- add permission for AWS broker to create RDS read replicas

## security considerations

This permission is scoped to specific resources managed by the broker
