### PR TITLE
Add CNAME records for workshop

### DIFF
--- a/terraform/stacks/dns/workshop.tf
+++ b/terraform/stacks/dns/workshop.tf
@@ -1,0 +1,19 @@
+#########################################
+## Production                          ##
+## pointers to gsa.gitlab-dedicated.us ##
+#########################################
+resource "aws_route53_record" "cloud_gov_workshop_cloud_gov_cname" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "workshop.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["gsa.gitlab-dedicated.us."]
+}
+
+resource "aws_route53_record" "cloud_gov_registry_workshop_cloud_gov_cname" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "registry.workshop.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["registry.gsa.gitlab-dedicated.us."]
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- add DNS records for `workshop.cloud.gov` and `registry.workshop.cloud.gov`

## security considerations

None immediately, these records will need to be updated or removed whenever we move away from gitlab dedicated to ensure they're not able to be taken over