### PR TITLE
Remove ability to turn off require_ssl for postgres

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -403,7 +403,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_defectdojo_development: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_development: "postgres16"
-          TF_VAR_rds_force_ssl_defectdojo_development: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_defectdojo_development: true
           TF_VAR_rds_shared_preload_libraries_defectdojo_development: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_development: true
@@ -413,7 +412,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_defectdojo_staging: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_staging: "postgres16"
-          TF_VAR_rds_force_ssl_defectdojo_staging: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_defectdojo_staging: true
           TF_VAR_rds_shared_preload_libraries_defectdojo_staging: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_staging: true
@@ -422,7 +420,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_defectdojo_production: "16.8"
           TF_VAR_rds_parameter_group_family_defectdojo_production: "postgres16"
-          TF_VAR_rds_force_ssl_defectdojo_production: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_defectdojo_production: true
           TF_VAR_rds_shared_preload_libraries_defectdojo_production: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_defectdojo_production: true
@@ -431,7 +428,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_bosh: "15.12"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
-          TF_VAR_rds_force_ssl_bosh: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_bosh: true
@@ -448,7 +444,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_credhub_staging: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
-          TF_VAR_rds_force_ssl_credhub_staging: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_credhub_staging: true
           TF_VAR_rds_shared_preload_libraries_credhub_staging: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_credhub_staging: true
@@ -458,7 +453,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_credhub_production: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
-          TF_VAR_rds_force_ssl_credhub_production: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_credhub_production: true
           TF_VAR_rds_shared_preload_libraries_credhub_production: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_credhub_production: true
@@ -467,7 +461,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_concourse_staging: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
-          TF_VAR_rds_force_ssl_concourse_staging: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_concourse_staging: true
           TF_VAR_rds_shared_preload_libraries_concourse_staging: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_concourse_staging: true
@@ -477,7 +470,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_concourse_production: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
-          TF_VAR_rds_force_ssl_concourse_production: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_concourse_production: true
           TF_VAR_rds_shared_preload_libraries_concourse_production: "pgaudit,pg_stat_statements"
           TF_VAR_rds_add_pgaudit_log_parameter_concourse_production: true
@@ -486,7 +478,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_opsuaa: "16.8"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
-          TF_VAR_rds_force_ssl_opsuaa: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_opsuaa: true
           TF_VAR_rds_shared_preload_libraries_opsuaa: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_opsuaa: true
@@ -763,7 +754,6 @@ jobs:
           TF_VAR_vpc_cidr: ((development_vpc_cidr))
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
-          TF_VAR_rds_force_ssl: 1
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
@@ -773,7 +763,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
-          TF_VAR_rds_force_ssl_cf: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_cf: true
           TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_cf: true
@@ -795,7 +784,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-          TF_VAR_rds_force_ssl_autoscaler: 1
           TF_VAR_rds_add_log_replication_commands_autoscaler: true
 
 
@@ -1045,7 +1033,6 @@ jobs:
           #TF_VAR_rds_allow_major_version_upgrade: "true"
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
-          TF_VAR_rds_force_ssl: 1
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_bosh: true
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
@@ -1055,7 +1042,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
-          TF_VAR_rds_force_ssl_cf: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_cf: true
           TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_cf: true
@@ -1074,7 +1060,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-          TF_VAR_rds_force_ssl_autoscaler: 1
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_autoscaler: true
           TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
@@ -1320,7 +1305,6 @@ jobs:
           # IDs from `data` resources.
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
-          TF_VAR_rds_force_ssl: 1
           TF_VAR_rds_password: ((production_rds_password))
           TF_VAR_rds_db_size: ((production_rds_db_size))
 
@@ -1345,7 +1329,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-          TF_VAR_rds_force_ssl_autoscaler: 1
 
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_autoscaler: true
           TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
@@ -1359,7 +1342,6 @@ jobs:
           TF_VAR_cf_as_rds_instance_type: ((production_cf_as_rds_instance_type))
           TF_VAR_rds_db_engine_version_cf: "16.8"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
-          TF_VAR_rds_force_ssl_cf: 1
           TF_VAR_rds_add_pgaudit_to_shared_preload_libraries_cf: true
           TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_add_pgaudit_log_parameter_cf: true

--- a/terraform/modules/autoscaler/database.tf
+++ b/terraform/modules/autoscaler/database.tf
@@ -14,7 +14,6 @@ module "cf_as_database" {
   rds_parameter_group_family      = var.rds_parameter_group_family
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
-  rds_force_ssl                   = var.rds_force_ssl
 
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_autoscaler
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_autoscaler

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -48,10 +48,6 @@ variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_autoscaler" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -14,7 +14,6 @@ module "cf_database_96" {
   rds_parameter_group_family                  = var.rds_parameter_group_family
   rds_allow_major_version_upgrade             = var.rds_allow_major_version_upgrade
   rds_apply_immediately                       = var.rds_apply_immediately
-  rds_force_ssl                               = var.rds_force_ssl
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -72,10 +72,6 @@ variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "stack_prefix" {
 }
 

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -19,7 +19,6 @@ module "rds_96" {
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
   performance_insights_enabled    = var.performance_insights_enabled
-  rds_force_ssl                   = var.rds_force_ssl
 
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -99,10 +99,6 @@ variable "performance_insights_enabled" {
   default = "false"
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool

--- a/terraform/modules/credhub/rds.tf
+++ b/terraform/modules/credhub/rds.tf
@@ -18,7 +18,6 @@ module "rds_96" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
-  rds_force_ssl                   = var.rds_force_ssl
 
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -93,10 +93,6 @@ variable "hosts" {
   type = list(string)
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool

--- a/terraform/modules/defect_dojo/rds.tf
+++ b/terraform/modules/defect_dojo/rds.tf
@@ -18,7 +18,6 @@ module "rds_96" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
-  rds_force_ssl                   = var.rds_force_ssl
 
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter

--- a/terraform/modules/defect_dojo/variables.tf
+++ b/terraform/modules/defect_dojo/variables.tf
@@ -91,10 +91,6 @@ variable "hosts" {
   type = list(string)
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -30,7 +30,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
 
   parameter {
     name         = "rds.force_ssl"
-    value        = var.rds_force_ssl
+    value        = 1
     apply_method = "pending-reboot"
   }
 

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -42,10 +42,6 @@ variable "rds_security_groups" {
   type = list(string)
 }
 
-variable "rds_force_ssl" {
-  default = 0
-}
-
 variable "rds_parameter_group_name" {
   default = ""
 }

--- a/terraform/modules/rds_stig/parameter_group.tf
+++ b/terraform/modules/rds_stig/parameter_group.tf
@@ -30,7 +30,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
 
   parameter {
     name         = "rds.force_ssl"
-    value        = var.rds_force_ssl
+    value        = 1
     apply_method = "pending-reboot"
   }
 }

--- a/terraform/modules/rds_stig/variables.tf
+++ b/terraform/modules/rds_stig/variables.tf
@@ -42,10 +42,6 @@ variable "rds_security_groups" {
   type = list(string)
 }
 
-# postgres only
-variable "rds_force_ssl" {
-  default = 0
-}
 
 # mysql only
 variable "rds_require_secure_transport" {

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -55,7 +55,6 @@ module "rds" {
   rds_subnet_group                = module.rds_network.rds_subnet_group
   rds_security_groups             = [module.rds_network.rds_postgres_security_group]
   rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_force_ssl                   = var.rds_force_ssl
 
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_bosh
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_bosh
@@ -79,7 +78,6 @@ module "credhub_rds" {
   rds_subnet_group                = module.rds_network.rds_subnet_group
   rds_security_groups             = [module.rds_network.rds_postgres_security_group]
   rds_parameter_group_name        = var.rds_parameter_group_name
-  rds_force_ssl                   = var.credhub_rds_force_ssl
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_parameter_group_family      = var.credhub_rds_parameter_group_family

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -202,14 +202,6 @@ variable "rds_parameter_group_name" {
   default = ""
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
-variable "credhub_rds_force_ssl" {
-  default = 1
-}
-
 variable "bosh_default_ssh_public_key" {
 
 }

--- a/terraform/modules/stack/base_v2/base.tf
+++ b/terraform/modules/stack/base_v2/base.tf
@@ -40,7 +40,6 @@ module "rds" {
   rds_db_name                     = var.rds_db_name
   rds_db_size                     = var.rds_db_size
   rds_db_storage_type             = var.rds_db_storage_type
-  rds_force_ssl                   = var.rds_force_ssl
   rds_instance_type               = var.rds_instance_type
   rds_multi_az                    = var.rds_multi_az
   rds_parameter_group_family      = var.rds_parameter_group_family
@@ -62,7 +61,6 @@ module "protobosh_rds" {
   rds_db_name                     = var.protobosh_rds_db_name
   rds_db_size                     = var.protobosh_rds_db_size
   rds_db_storage_type             = var.protobosh_rds_db_storage_type
-  rds_force_ssl                   = var.protobosh_rds_force_ssl
   rds_instance_type               = var.protobosh_rds_instance_type
   rds_multi_az                    = var.protobosh_rds_multi_az
   rds_parameter_group_family      = var.protobosh_rds_parameter_group_family

--- a/terraform/modules/stack/base_v2/variables.tf
+++ b/terraform/modules/stack/base_v2/variables.tf
@@ -156,10 +156,6 @@ variable "rds_parameter_group_name" {
   default = ""
 }
 
-variable "protobosh_rds_force_ssl" {
-  default = 1
-}
-
 variable "protobosh_rds_multi_az" {
   default = "true"
 }
@@ -191,10 +187,6 @@ variable "s3_gateway_policy_accounts" {
   default = []
 }
 
-
-variable "rds_force_ssl" {
-  default = 1
-}
 
 variable "rds_db_storage_type" {
   default = "gp3"

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -20,7 +20,6 @@ module "base" {
   rds_db_engine                      = var.rds_db_engine
   rds_db_engine_version              = var.rds_db_engine_version
   rds_parameter_group_family         = var.rds_parameter_group_family
-  rds_force_ssl                      = var.rds_force_ssl
   rds_allow_major_version_upgrade    = var.rds_allow_major_version_upgrade
   rds_apply_immediately              = var.rds_apply_immediately
   rds_username                       = var.rds_username

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -83,10 +83,6 @@ variable "rds_username" {
   default = "bosh"
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "restricted_ingress_web_cidrs" {
   type    = list(string)
   default = ["127.0.0.1/32", "192.168.0.1/24"]

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -195,7 +195,6 @@ module "stack" {
   rds_instance_type                       = var.rds_instance_type
   rds_db_engine_version                   = var.rds_db_engine_version
   rds_parameter_group_family              = var.rds_parameter_group_family
-  rds_force_ssl                           = var.rds_force_ssl
   public_cidr_1                           = cidrsubnet(var.vpc_cidr, 8, 100)
   public_cidr_2                           = cidrsubnet(var.vpc_cidr, 8, 101)
   private_cidr_1                          = cidrsubnet(var.vpc_cidr, 8, 1)
@@ -279,7 +278,6 @@ module "cf" {
   stack_prefix                                = "cf-${var.stack_description}"
   rds_db_engine_version                       = var.rds_db_engine_version_cf
   rds_parameter_group_family                  = var.rds_parameter_group_family_cf
-  rds_force_ssl                               = var.rds_force_ssl_cf
   rds_add_pgaudit_to_shared_preload_libraries = var.rds_add_pgaudit_to_shared_preload_libraries_cf
   rds_add_pgaudit_log_parameter               = var.rds_add_pgaudit_log_parameter_cf
   rds_shared_preload_libraries                = var.rds_shared_preload_libraries_cf
@@ -338,7 +336,6 @@ module "autoscaler" {
   rds_instance_type               = var.cf_as_rds_instance_type
   rds_db_engine_version           = var.rds_db_engine_version_autoscaler
   rds_parameter_group_family      = var.rds_parameter_group_family_autoscaler
-  rds_force_ssl                   = var.rds_force_ssl_autoscaler
 
   rds_add_pgaudit_to_shared_preload_libraries_autoscaler = var.rds_add_pgaudit_to_shared_preload_libraries_autoscaler
   rds_add_pgaudit_log_parameter_autoscaler               = var.rds_add_pgaudit_log_parameter_autoscaler

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -32,10 +32,6 @@ variable "rds_parameter_group_family" {
   default = "postgres12"
 }
 
-variable "rds_force_ssl" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_bosh" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -74,10 +70,6 @@ variable "rds_parameter_group_family_autoscaler" {
   default = "postgres15"
 }
 
-variable "rds_force_ssl_autoscaler" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_autoscaler" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -114,10 +106,6 @@ variable "rds_db_engine_version_cf" {
 
 variable "rds_parameter_group_family_cf" {
   default = "postgres16"
-}
-
-variable "rds_force_ssl_cf" {
-  default = 1
 }
 
 variable "cf_rds_password" {

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -14,7 +14,6 @@ module "opsuaa_db" {
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_db_engine_version           = var.rds_db_engine_version_opsuaa
   rds_parameter_group_family      = var.rds_parameter_group_family_opsuaa
-  rds_force_ssl                   = var.rds_force_ssl_opsuaa
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
 

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -108,7 +108,6 @@ module "stack" {
   rds_security_groups_count              = "1"
   rds_db_engine_version                  = var.rds_db_engine_version_bosh
   rds_parameter_group_family             = var.rds_parameter_group_family_bosh
-  rds_force_ssl                          = var.rds_force_ssl_bosh
   rds_allow_major_version_upgrade        = var.rds_allow_major_version_upgrade
   rds_apply_immediately                  = var.rds_apply_immediately
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key
@@ -151,7 +150,6 @@ module "concourse_production" {
   rds_parameter_group_family      = var.rds_parameter_group_family_concourse_production
   rds_db_engine_version           = var.rds_db_engine_version_concourse_production
   rds_apply_immediately           = var.rds_apply_immediately
-  rds_force_ssl                   = var.rds_force_ssl_concourse_production
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   performance_insights_enabled    = "true"
   rds_instance_type               = "db.m5.4xlarge"
@@ -188,7 +186,6 @@ module "concourse_staging" {
   rds_parameter_group_family      = var.rds_parameter_group_family_concourse_staging
   rds_db_engine_version           = var.rds_db_engine_version_concourse_staging
   rds_apply_immediately           = var.rds_apply_immediately
-  rds_force_ssl                   = var.rds_force_ssl_concourse_staging
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
   rds_db_size                     = 400
@@ -223,7 +220,6 @@ module "credhub_production" {
   rds_parameter_group_family      = var.rds_parameter_group_family_credhub_production
   rds_db_engine_version           = var.rds_db_engine_version_credhub_production
   rds_apply_immediately           = var.rds_apply_immediately
-  rds_force_ssl                   = var.rds_force_ssl_credhub_production
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
   rds_multi_az                    = var.rds_multi_az
@@ -255,7 +251,6 @@ module "credhub_staging" {
   rds_parameter_group_family      = var.rds_parameter_group_family_credhub_staging
   rds_db_engine_version           = var.rds_db_engine_version_credhub_staging
   rds_apply_immediately           = var.rds_apply_immediately
-  rds_force_ssl                   = var.rds_force_ssl_credhub_staging
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
   rds_db_size                     = 400
@@ -290,7 +285,6 @@ module "defectdojo_development" {
   rds_parameter_group_name        = "tooling-defectdojo-development"
   rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo_development
   rds_db_engine_version           = var.rds_db_engine_version_defectdojo_development
-  rds_force_ssl                   = var.rds_force_ssl_defectdojo_development
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.t3.medium"
@@ -326,7 +320,6 @@ module "defectdojo_staging" {
   rds_parameter_group_name        = "tooling-defectdojo-staging"
   rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo_staging
   rds_db_engine_version           = var.rds_db_engine_version_defectdojo_staging
-  rds_force_ssl                   = var.rds_force_ssl_defectdojo_staging
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"
@@ -361,7 +354,6 @@ module "defectdojo_production" {
   rds_parameter_group_name        = "tooling-defectdojo-production"
   rds_parameter_group_family      = var.rds_parameter_group_family_defectdojo_production
   rds_db_engine_version           = var.rds_db_engine_version_defectdojo_production
-  rds_force_ssl                   = var.rds_force_ssl_defectdojo_staging
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -45,10 +45,6 @@ variable "rds_parameter_group_family_bosh" {
   default = "postgres15"
 }
 
-variable "rds_force_ssl_bosh" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_bosh" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -85,10 +81,6 @@ variable "rds_db_engine_version_credhub_staging" {
 
 variable "rds_parameter_group_family_credhub_staging" {
   default = "postgres15"
-}
-
-variable "rds_force_ssl_credhub_staging" {
-  default = 1
 }
 
 variable "rds_add_pgaudit_to_shared_preload_libraries_credhub_staging" {
@@ -129,10 +121,6 @@ variable "rds_parameter_group_family_credhub_production" {
   default = "postgres15"
 }
 
-variable "rds_force_ssl_credhub_production" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_credhub_production" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -169,10 +157,6 @@ variable "rds_db_engine_version_concourse_staging" {
 
 variable "rds_parameter_group_family_concourse_staging" {
   default = "postgres15"
-}
-
-variable "rds_force_ssl_concourse_staging" {
-  default = 1
 }
 
 variable "rds_add_pgaudit_to_shared_preload_libraries_concourse_staging" {
@@ -213,10 +197,6 @@ variable "rds_parameter_group_family_concourse_production" {
   default = "postgres15"
 }
 
-variable "rds_force_ssl_concourse_production" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_concourse_production" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -253,10 +233,6 @@ variable "rds_db_engine_version_opsuaa" {
 
 variable "rds_parameter_group_family_opsuaa" {
   default = "postgres16"
-}
-
-variable "rds_force_ssl_opsuaa" {
-  default = 1
 }
 
 variable "rds_add_pgaudit_to_shared_preload_libraries_opsuaa" {
@@ -538,10 +514,6 @@ variable "rds_parameter_group_family_defectdojo_development" {
   default = "postgres16"
 }
 
-variable "rds_force_ssl_defectdojo_development" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_defectdojo_development" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -580,10 +552,6 @@ variable "rds_parameter_group_family_defectdojo_staging" {
   default = "postgres16"
 }
 
-variable "rds_force_ssl_defectdojo_staging" {
-  default = 1
-}
-
 variable "rds_add_pgaudit_to_shared_preload_libraries_defectdojo_staging" {
   description = "Whether to enable pgaudit in shared_preload_libraries"
   type        = bool
@@ -620,10 +588,6 @@ variable "rds_db_engine_version_defectdojo_production" {
 
 variable "rds_parameter_group_family_defectdojo_production" {
   default = "postgres16"
-}
-
-variable "rds_force_ssl_defectdojo_production" {
-  default = 1
 }
 
 variable "rds_add_pgaudit_to_shared_preload_libraries_defectdojo_production" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove the ability to override the require_ssl parameter group option, the default is to enable this now that all current RDS platform instances have this enabled.  
- Removes 138 lines of terraform hcl from requiring maintenance
- Part of https://github.com/cloud-gov/private/issues/2529
-

## security considerations
Results in no changes to current running infrastructure
