### PR TITLE
add trailing dot to DNS records

### DIFF
--- a/terraform/modules/environment_dns/dns.tf
+++ b/terraform/modules/environment_dns/dns.tf
@@ -224,7 +224,7 @@ resource "aws_route53_record" "brokered_mail_ns" {
 }
 
 locals {
-  external_domain               = "external-domains-${var.stack_name}.cloud.gov."
+  external_domain               = "external-domains-${var.stack_name}.cloud.gov"
   csb_helper_domain_name        = "services.${var.domain}."
   csb_helper_domain_record      = "services.${var.domain}.${local.external_domain}."
   csb_helper_acme_domain_name   = "_acme-challenge.services.${var.domain}."

--- a/terraform/modules/environment_dns/dns.tf
+++ b/terraform/modules/environment_dns/dns.tf
@@ -224,11 +224,11 @@ resource "aws_route53_record" "brokered_mail_ns" {
 }
 
 locals {
-  external_domain               = "external-domains-${var.stack_name}.cloud.gov"
+  external_domain               = "external-domains-${var.stack_name}.cloud.gov."
   csb_helper_domain_name        = "services.${var.domain}."
-  csb_helper_domain_record      = "services.${var.domain}.${local.external_domain}"
+  csb_helper_domain_record      = "services.${var.domain}.${local.external_domain}."
   csb_helper_acme_domain_name   = "_acme-challenge.services.${var.domain}."
-  csb_helper_acme_domain_record = "_acme-challenge.services.${var.domain}.${local.external_domain}"
+  csb_helper_acme_domain_record = "_acme-challenge.services.${var.domain}.${local.external_domain}."
 }
 
 // DNS records corresponding to the External Domain Service Instance


### PR DESCRIPTION
## Changes proposed in this pull request:

When Route53 saves DNS records, it adds a trailing `.`. However, the records are defined in the Terraform code without the trailing `.`. Thus, on every plan/apply, Terraform detects a change on these records, even though they aren't changing.

This PR updates the TF to include the trailing `.` on the DNS records to fix the confusing Terraform change detection.

## security considerations

None. There is no material change to the DNS records here
