### PR TITLE
remove on_success slack notifications

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -127,7 +127,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-development
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &external-development-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-development
@@ -166,7 +166,7 @@ jobs:
             passed: [plan-external-development]
       - task: terraform-apply-external-development
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *external-development-params
           TERRAFORM_ACTION: apply
@@ -188,7 +188,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &external-staging-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-staging
@@ -226,7 +226,7 @@ jobs:
             passed: [plan-external-staging]
       - task: terraform-apply-external-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *external-staging-params
           TERRAFORM_ACTION: apply
@@ -248,7 +248,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &external-production-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-production
@@ -277,7 +277,7 @@ jobs:
             passed: [plan-external-production]
       - task: terraform-apply-external-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *external-production-params
           TERRAFORM_ACTION: apply
@@ -299,7 +299,7 @@ jobs:
             trigger: true
       - task: plan-dns
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &dns-params
           TERRAFORM_ACTION: plan
           STACK_NAME: dns
@@ -324,7 +324,7 @@ jobs:
             passed: [plan-dns]
       - task: terraform-apply-dns
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *dns-params
           TERRAFORM_ACTION: apply
@@ -340,7 +340,7 @@ jobs:
       - task: terraform-plan-tooling
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tooling-params
           TERRAFORM_ACTION: plan
           STACK_NAME: tooling
@@ -429,8 +429,7 @@ jobs:
           TF_VAR_rds_db_engine_version_credhub_staging: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
           TF_VAR_rds_shared_preload_libraries_credhub_staging: "pgaudit,pg_stat_statements"
-          TF_VAR_rds_pgaudit_log_values_credhub_staging: "ddl,role" 
-
+          TF_VAR_rds_pgaudit_log_values_credhub_staging: "ddl,role"
 
           TF_VAR_rds_db_engine_version_credhub_production: "15.12"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
@@ -442,7 +441,6 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_concourse_staging: "pgaudit,pg_stat_statements"
           TF_VAR_rds_pgaudit_log_values_concourse_staging: "ddl,role"
 
-
           TF_VAR_rds_db_engine_version_concourse_production: "15.12"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
           TF_VAR_rds_shared_preload_libraries_concourse_production: "pgaudit,pg_stat_statements"
@@ -452,7 +450,6 @@ jobs:
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
           TF_VAR_rds_shared_preload_libraries_opsuaa: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_pgaudit_log_values_opsuaa: "ddl,role"
-
 
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
@@ -467,7 +464,7 @@ jobs:
       - task: terraform-apply-tooling
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tooling-params
           TERRAFORM_ACTION: apply
@@ -696,7 +693,7 @@ jobs:
       - task: terraform-plan-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &development-params
           TERRAFORM_ACTION: plan
           STACK_NAME: development
@@ -732,7 +729,6 @@ jobs:
           TF_VAR_rds_shared_preload_libraries_cf: "pgaudit,pg_stat_statements,pg_tle"
           TF_VAR_rds_pgaudit_log_values_cf: "ddl,role"
 
-
           TF_VAR_cf_rds_password: ((development_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((development_cf_as_rds_instance_type))
           TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
@@ -744,7 +740,6 @@ jobs:
 
           TF_VAR_rds_db_engine_version_autoscaler: "15.12"
           TF_VAR_rds_parameter_group_family_autoscaler: "postgres15"
-
 
           TF_VAR_rds_shared_preload_libraries_autoscaler: "pgaudit,pg_stat_statements"
           TF_VAR_rds_pgaudit_log_values_autoscaler: "ddl,role"
@@ -800,7 +795,7 @@ jobs:
       - task: terraform-apply-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *development-params
           TERRAFORM_ACTION: apply
@@ -943,15 +938,6 @@ jobs:
         channel: ((slack-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-    on_success:
-      put: slack
-      params:
-        text: |
-          :white_check_mark: WAF Rules Test Development PASSED
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel))
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
 
   - name: plan-staging
     plan:
@@ -966,7 +952,7 @@ jobs:
       - task: terraform-plan-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &staging-params
           TERRAFORM_ACTION: plan
           STACK_NAME: staging
@@ -1065,7 +1051,7 @@ jobs:
       - task: terraform-apply-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *staging-params
           TERRAFORM_ACTION: apply
@@ -1208,15 +1194,6 @@ jobs:
         channel: ((slack-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-    on_success:
-      put: slack
-      params:
-        text: |
-          :white_check_mark: WAF Rules Test Staging PASSED
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel))
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
 
   - name: plan-production
     plan:
@@ -1231,7 +1208,7 @@ jobs:
       - task: terraform-plan-production
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &production-params
           TERRAFORM_ACTION: plan
           STACK_NAME: production
@@ -1329,7 +1306,7 @@ jobs:
       - task: terraform-apply-production
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *production-params
           TERRAFORM_ACTION: apply
@@ -1472,15 +1449,6 @@ jobs:
         channel: ((slack-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-    on_success:
-      put: slack
-      params:
-        text: |
-          :white_check_mark: WAF Rules Test Production PASSED
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel))
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
 
   - name: plan-ecr
     plan:
@@ -1492,7 +1460,7 @@ jobs:
             trigger: true
       - task: terraform-plan-ecr
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tf-ecr
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/ecr
@@ -1511,7 +1479,7 @@ jobs:
             passed: [plan-ecr]
       - task: terraform-apply-ecr
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tf-ecr
           TERRAFORM_ACTION: apply
@@ -1526,7 +1494,7 @@ jobs:
             trigger: true
       - task: terraform-plan-concourse-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tf-concourse-staging
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/concourse
@@ -1549,7 +1517,7 @@ jobs:
             passed: [plan-concourse-staging]
       - task: terraform-apply-concourse-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tf-concourse-staging
           TERRAFORM_ACTION: apply
@@ -1564,7 +1532,7 @@ jobs:
             trigger: true
       - task: terraform-plan-concourse-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tf-concourse-production
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/concourse
@@ -1587,7 +1555,7 @@ jobs:
             passed: [plan-concourse-production]
       - task: terraform-apply-concourse-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tf-concourse-production
           TERRAFORM_ACTION: apply


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove on_success slack notifications. Slack notifications notifying success require no action and just produce noise

## security considerations

Removing notifications on job success in Slack has no security impact
