### PR TITLE
Update AWS Provider to 6.2.1

### DIFF
--- a/terraform/modules/bosh_vpc/versions.tf
+++ b/terraform/modules/bosh_vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/bosh_vpc_v2/versions.tf
+++ b/terraform/modules/bosh_vpc_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/cdn_broker/versions.tf
+++ b/terraform/modules/cdn_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/cloudfoundry/versions.tf
+++ b/terraform/modules/cloudfoundry/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/cloudfront/versions.tf
+++ b/terraform/modules/cloudfront/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/cloudwatch/versions.tf
+++ b/terraform/modules/cloudwatch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/concourse/versions.tf
+++ b/terraform/modules/concourse/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/concourse_v2/versions.tf
+++ b/terraform/modules/concourse_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/credhub/versions.tf
+++ b/terraform/modules/credhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/credhub_v2/versions.tf
+++ b/terraform/modules/credhub_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/csb/broker/versions.tf
+++ b/terraform/modules/csb/broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/modules/csb/iam/commercial/versions.tf
+++ b/terraform/modules/csb/iam/commercial/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/csb/iam/govcloud/versions.tf
+++ b/terraform/modules/csb/iam/govcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/cvd_mirror/versions.tf
+++ b/terraform/modules/cvd_mirror/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/cvd_mirror_v2/versions.tf
+++ b/terraform/modules/cvd_mirror_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/defect_dojo/versions.tf
+++ b/terraform/modules/defect_dojo/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/diego/versions.tf
+++ b/terraform/modules/diego/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/dns/versions.tf
+++ b/terraform/modules/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/elasticache_broker_network/versions.tf
+++ b/terraform/modules/elasticache_broker_network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/elasticsearch_broker/versions.tf
+++ b/terraform/modules/elasticsearch_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/environment_dns/versions.tf
+++ b/terraform/modules/environment_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/external_domain_broker/versions.tf
+++ b/terraform/modules/external_domain_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_govcloud/versions.tf
+++ b/terraform/modules/external_domain_broker_govcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_loadbalancer_group/versions.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_tests/versions.tf
+++ b/terraform/modules/external_domain_broker_tests/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role/versions.tf
+++ b/terraform/modules/iam_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/aws_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/blobstore/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/bosh/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/cloudwatch/versions.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/compliance_role/versions.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/concourse_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/ecr/versions.tf
+++ b/terraform/modules/iam_role_policy/ecr/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/logs_opensearch_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logs_opensearch_ingestor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/logs_opensearch_metric_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logs_opensearch_metric_ingestor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/logs_opensearch_s3_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logs_opensearch_s3_ingestor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker_task/versions.tf
+++ b/terraform/modules/iam_role_policy/s3_broker_task/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/billing_user/versions.tf
+++ b/terraform/modules/iam_user/billing_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/cvd_sync/versions.tf
+++ b/terraform/modules/iam_user/cvd_sync/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/ecr_pull_user/versions.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/ecr_user/versions.tf
+++ b/terraform/modules/iam_user/ecr_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/health_check/versions.tf
+++ b/terraform/modules/iam_user/health_check/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/iam_cert_provision/versions.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/lets_encrypt/versions.tf
+++ b/terraform/modules/iam_user/lets_encrypt/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/limit_check_user/versions.tf
+++ b/terraform/modules/iam_user/limit_check_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/rds_storage_alert/versions.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/s3_bucket_readonly/versions.tf
+++ b/terraform/modules/iam_user/s3_bucket_readonly/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/s3_logstash/versions.tf
+++ b/terraform/modules/iam_user/s3_logstash/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/iam_user/terraform_provision/versions.tf
+++ b/terraform/modules/iam_user/terraform_provision/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/jumpbox/versions.tf
+++ b/terraform/modules/jumpbox/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/logsearch/versions.tf
+++ b/terraform/modules/logsearch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/monitoring/versions.tf
+++ b/terraform/modules/monitoring/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/monitoring_v2/versions.tf
+++ b/terraform/modules/monitoring_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/mysql_stig/db/versions.tf
+++ b/terraform/modules/mysql_stig/db/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/rds/versions.tf
+++ b/terraform/modules/rds/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/rds_network/versions.tf
+++ b/terraform/modules/rds_network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/rds_network_v2/versions.tf
+++ b/terraform/modules/rds_network_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/rds_stig/versions.tf
+++ b/terraform/modules/rds_stig/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/regionalmaster_dns/versions.tf
+++ b/terraform/modules/regionalmaster_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/s3_bucket/encrypted_bucket_v2/versions.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/s3_bucket/semver_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/semver_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/shibboleth/versions.tf
+++ b/terraform/modules/shibboleth/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/smtp/versions.tf
+++ b/terraform/modules/smtp/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/sns/versions.tf
+++ b/terraform/modules/sns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/stack/base/versions.tf
+++ b/terraform/modules/stack/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/stack/base_v2/versions.tf
+++ b/terraform/modules/stack/base_v2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/modules/vpc_peering/versions.tf
+++ b/terraform/modules/vpc_peering/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "< 6.0.0"
+      version               = "< 6.2.1"
       configuration_aliases = [aws, aws.tooling]
     }
   }

--- a/terraform/modules/vpc_peering_sg/versions.tf
+++ b/terraform/modules/vpc_peering_sg/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "< 6.0.0"
+      version               = "< 6.2.1"
       configuration_aliases = [aws]
     }
   }

--- a/terraform/stacks/bootstrap-westa-hub/versions.tf
+++ b/terraform/stacks/bootstrap-westa-hub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/stacks/dns-westa-hub/versions.tf
+++ b/terraform/stacks/dns-westa-hub/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/stacks/ecr/versions.tf
+++ b/terraform/stacks/ecr/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/stacks/main/versions.tf
+++ b/terraform/stacks/main/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }

--- a/terraform/stacks/westa-hub/versions.tf
+++ b/terraform/stacks/westa-hub/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.0.0"
+      version = "< 6.2.1"
     }
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move hasicorp/aws to use 6.2.1 

## security considerations
Running latest versions of code keeps the platform secure
