### PR TITLE
set auth_token_update_strategy for elasticache replication

### DIFF
--- a/terraform/modules/elasticache_replication_group/elasticache.tf
+++ b/terraform/modules/elasticache_replication_group/elasticache.tf
@@ -5,6 +5,7 @@ resource "random_password" "password" {
 }
 
 resource "aws_elasticache_replication_group" "replication_group" {
+  auth_token_update_strategy = "ROTATE"
   replication_group_id       = "${var.cluster_name}-cluster"
   description                = "${var.cluster_name} cluster"
   node_type                  = var.node_type


### PR DESCRIPTION
## Changes proposed in this pull request:

- set auth_token_update_strategy to "ROTATE" for elasticache replication group

## security considerations

None, just preserving setting in TF so it doesn't get clobbered on the next apply
