### PR TITLE
make ecr repo for clamav-rest for malware scanning

### DIFF
--- a/terraform/stacks/ecr/variables.tf
+++ b/terraform/stacks/ecr/variables.tf
@@ -14,6 +14,7 @@ variable "repositories" {
     "cf-resource",
     "cflinuxfs4-hardened",           # hardened stack passed cf-acceptance tests
     "cflinuxfs4-hardened-candidate", # hardened stack not yet passed cf-acceptance tests
+    "clamav-rest",                   # image for malware scanning service
     "cloud-service-broker",
     "cloudfoundry-cflinuxfs4", # current stack in CF
     "concourse-http-jq-resource",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add an ECR repo for the clamav-rest image (malware scanning service in support of Pages file uploads)

## security considerations

Malware scanning is good. 
