### PR TITLE
Must be false because variables can't be used here

### DIFF
--- a/terraform/modules/rds_stig/database.tf
+++ b/terraform/modules/rds_stig/database.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "rds_database" {
 
   lifecycle {
     ignore_changes  = [identifier]
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   identifier = "${var.stack_description}-${element(split("-", uuid()), 4)}"


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- I don't see a way to readily parameterize this since literals are required.
- Needed so I can refresh the mysql_stig test instance.
- https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#literal-values-only 

## security considerations
OK, but I have to remember to change to true later (or fix in a way that meets our needs)
