### PR TITLE
update CreateWebACL perms for external domain broker 

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -19,6 +19,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       variable = "aws:PrincipalArn"
       values   = [aws_iam_user.iam_user.arn]
     }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
   }
 
   statement {
@@ -32,6 +37,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       test     = "StringEquals"
       variable = "aws:PrincipalArn"
       values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
     }
   }
 
@@ -48,6 +58,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       variable = "aws:PrincipalArn"
       values   = [aws_iam_user.iam_user.arn]
     }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
   }
 
   statement {
@@ -62,6 +77,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       test     = "StringEquals"
       variable = "aws:PrincipalArn"
       values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
     }
   }
 
@@ -78,6 +98,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       test     = "StringEquals"
       variable = "aws:PrincipalArn"
       values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
     }
   }
 
@@ -100,11 +125,35 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       variable = "iam:AWSServiceName"
       values   = ["wafv2.amazonaws.com"]
     }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
   }
 
   statement {
     actions = [
-      "wafv2:CreateWebACL",
+      "wafv2:CreateWebACL"
+    ]
+    resources = [
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:regional/webacl/cg-external-domains-*",
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:regional/managedruleset/*/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
+  }
+
+  statement {
+    actions = [
       "wafv2:TagResource",
       "wafv2:UntagResource",
       "wafv2:GetWebACL"
@@ -116,6 +165,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       test     = "StringEquals"
       variable = "aws:PrincipalArn"
       values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
     }
   }
 
@@ -136,6 +190,11 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       test     = "ArnLike"
       variable = "wafv2:LogDestinationResource"
       values   = [var.waf_log_group_arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
     }
   }
 }

--- a/terraform/modules/external_domain_broker_govcloud/variables.tf
+++ b/terraform/modules/external_domain_broker_govcloud/variables.tf
@@ -18,3 +18,8 @@ variable "waf_log_group_arn" {
   type        = string
   description = "ARN of CloudWatch log group for WAF logs"
 }
+
+variable "environment_nat_egress_ips" {
+  type        = list(string)
+  description = "List of IPs for traffic egressing the VPC in this environment"
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -424,6 +424,10 @@ module "external_domain_broker_govcloud" {
   aws_region        = data.aws_region.current.region
   aws_partition     = data.aws_partition.current.partition
   waf_log_group_arn = module.cf.waf_log_group_arn
+  environment_nat_egress_ips = [
+    module.stack.nat_egress_ip_az1,
+    module.stack.nat_egress_ip_az2,
+  ]
 }
 
 module "dns_logging" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- update CreateWebACL perms for external domain broker
- add source IP conditions on external domain broker IAM policy

## security considerations

The CreateWebACL permissions are the least privilege necessary for the external domain broker. I tried to refine the permissions for the `managedruleset/*/*` to a more specific set of resources, but I could not find any documentation online for the expected ARNs of AWS managed rules. Instead, as an additional security measure, I added a `aws:sourceIp` condition to all of the IAM policy statements so that this IAM policy can only be used when identified as coming from within our network.