### PR TITLE
Add external domain broker WAF log perms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ terraform.json
 .project
 
 *-state.json
+.vscode

--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -197,6 +197,34 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       values   = var.environment_nat_egress_ips
     }
   }
+
+  # necessary permissions for sending WAF logs to CloudWatch
+  # see https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-permissions
+  #
+  # wildcard permissions are required for these actions
+  # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-actions-as-permissions
+  statement {
+    actions = [
+      "logs:CreateLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:PutResourcePolicy",
+      "logs:DescribeResourcePolicies",
+      "logs:DescribeLogGroups"
+    ]
+    resources = [
+      "*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
+  }
 }
 
 resource "aws_iam_user" "iam_user" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add IAM permissions for external domain broker to associate logging with WAF web ACLs

## security considerations

These new permissions require a `*` resource specification. See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html#amazoncloudwatchlogs-actions-as-permissions for documentation of the requirement to use `*` as the resource for these permissions. To compensate for this permissive resource specification, the policy limits these actions to only the given IAM user and only when the traffic is coming from certain IPs.
