### PR TITLE
adds an ECR repo for the clamav-rest candidate image 

### DIFF
--- a/terraform/stacks/ecr/variables.tf
+++ b/terraform/stacks/ecr/variables.tf
@@ -14,7 +14,8 @@ variable "repositories" {
     "cf-resource",
     "cflinuxfs4-hardened",           # hardened stack passed cf-acceptance tests
     "cflinuxfs4-hardened-candidate", # hardened stack not yet passed cf-acceptance tests
-    "clamav-rest",                   # image for malware scanning service
+    "clamav-rest",                   # image for malware scanning service which has passed testing
+    "clamav-rest-candidate",         # image for malware scanning service which has not yet passed testing
     "cloud-service-broker",
     "cloudfoundry-cflinuxfs4", # current stack in CF
     "concourse-http-jq-resource",


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds an ECR repository for a clamav-rest candidate image.
- Image candidates will be tested before being copied to the `clamav-rest` ECR repository for use.


## security considerations

We want to test images before publishing them to a repository for use/consumption. 
