### PR TITLE
add external domain broker permission to set web ACL on ALBs

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -226,6 +226,27 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       values   = var.environment_nat_egress_ips
     }
   }
+
+  # this permission can only use "*" as its resource constraint
+  # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_awselasticloadbalancingv2.html
+  statement {
+    actions = [
+      "elasticloadbalancing:SetWebACL"
+    ]
+    resources = [
+      "*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
+  }
 }
 
 resource "aws_iam_user" "iam_user" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- add external domain broker permission to set web ACL on ALBs

## security considerations

[The `elasticloadbalancing:SetWebACL` permission requires a resource constraint of `*` and cannot be constrained to a specific set of resources](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awselasticloadbalancingv2.html). However, the permission is limited to only being used by the given IAM user and for a specific set of IPs
