### PR TITLE
Remove WAF definition for LBs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2126,7 +2126,7 @@ resources:
     type: git
     source:
       uri: ((cg_provision_git_url))
-      branch: remove-edb-lb-waf
+      branch: ((cg_provision_git_branch_development))
       commit_verification_keys: ((cloud-gov-pgp-keys))
 
   - name: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2126,7 +2126,7 @@ resources:
     type: git
     source:
       uri: ((cg_provision_git_url))
-      branch: ((cg_provision_git_branch_development))
+      branch: remove-edb-lb-waf
       commit_verification_keys: ((cloud-gov-pgp-keys))
 
   - name: pull-request

--- a/terraform/modules/external_domain_broker_loadbalancer_group/resources.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/resources.tf
@@ -173,9 +173,12 @@ resource "aws_lb_target_group" "domains_lbgroup_gr_logstash_https" {
   }
 }
 
-resource "aws_wafv2_web_acl_association" "domain_waf" {
-  count = var.domains_lbgroup_count
+# Removed definition of WAF for these load balancers, which is now
+# handled by the broker
+removed {
+  from = aws_wafv2_web_acl_association.domain_waf
 
-  resource_arn = aws_lb.domains_lbgroup[count.index].arn
-  web_acl_arn  = var.waf_arn
+  lifecycle {
+    destroy = false
+  }
 }

--- a/terraform/modules/external_domain_broker_loadbalancer_group/variables.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/variables.tf
@@ -25,10 +25,6 @@ variable "vpc_id" {
 
 }
 
-variable "waf_arn" {
-
-}
-
 variable "wildcard_arn" {
 
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -97,7 +97,6 @@ module "dedicated_loadbalancer_group" {
   subnets                              = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
   security_groups                      = [module.stack.web_traffic_security_group]
   elb_bucket_name                      = module.log_bucket.elb_bucket_name
-  waf_arn                              = module.cf.cf_uaa_waf_core_arn
   logstash_hosts                       = var.logstash_hosts
   vpc_id                               = module.stack.vpc_id
   domains_lbgroup_count                = var.domains_lbgroup_count


### PR DESCRIPTION
## Changes proposed in this pull request:

- The `removed` blocks remove the management of resources from the Terraform state, but doesn't actually delete the resources: https://support.hashicorp.com/hc/en-us/articles/34185721057555-Removing-a-Resource-from-the-Terraform-State-Using-the-removed-block. This allows me to smoothly handle the transition to the WAF managed by the broker

## security considerations

We are not removing the WAF from these resources, just removing Terraform's management of it. So there is no loss of security here.
