### PR TITLE
Allow CSB to tag the IAM users

### DIFF
--- a/terraform/modules/csb/iam/govcloud/csb.tf
+++ b/terraform/modules/csb/iam/govcloud/csb.tf
@@ -29,6 +29,11 @@ data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
       "iam:TagUser"
     ]
     resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "aws:username"
+      values   = ["csb-aws-ses-*"]
+    }
   }
 
   statement {

--- a/terraform/modules/csb/iam/govcloud/csb.tf
+++ b/terraform/modules/csb/iam/govcloud/csb.tf
@@ -25,7 +25,8 @@ data "aws_iam_policy_document" "brokerpak_aws_ses_govcloud" {
       "iam:GetPolicy",
       "iam:AttachUserPolicy",
       "iam:DetachUserPolicy",
-      "iam:List*"
+      "iam:List*",
+      "iam:TagUser"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION

## Changes proposed in this pull request:
- The CSB tags all resources it creates with a standard set of tags so we can associate them with a service instance.

## security considerations
Expands CSB user's permissions.