### PR TITLE
Remove unused infrastructure

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -206,34 +206,6 @@ resource "aws_lb_listener_rule" "static_https" {
   }
 }
 
-## MAX 10 HOSTS
-resource "aws_lb_listener_rule" "domains_broker_logstash_listener_rule" {
-  count = var.domains_broker_alb_count
-
-  listener_arn = aws_lb_listener.domains_broker_https[count.index].arn
-
-  action {
-    type = "forward"
-
-    forward {
-      target_group {
-        arn    = aws_lb_target_group.domains_broker_logstash_https[count.index].arn
-        weight = var.loadbalancer_forward_original_weight
-      }
-      target_group {
-        arn    = aws_lb_target_group.domains_broker_gr_logstash_https[count.index].arn
-        weight = var.loadbalancer_forward_new_weight
-      }
-    }
-  }
-
-  condition {
-    host_header {
-      values = var.logstash_hosts
-    }
-  }
-}
-
 resource "aws_lb_target_group" "domains_broker_apps_https" {
   count = var.domains_broker_alb_count
 

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -224,48 +224,10 @@ resource "aws_lb_target_group" "domains_broker_apps_https" {
   }
 }
 
-resource "aws_lb_target_group" "domains_broker_logstash_https" {
-  count = var.domains_broker_alb_count
-
-  name     = "${var.stack_description}-domains-logstash-${count.index}"
-  port     = 443
-  protocol = "HTTPS"
-  vpc_id   = module.stack.vpc_id
-
-  health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-    timeout             = 4
-    interval            = 5
-    port                = 81
-    matcher             = 200
-  }
-}
-
 resource "aws_lb_target_group" "domains_broker_gr_apps_https" {
   count = var.domains_broker_alb_count
 
   name     = "${var.stack_description}-domains-gapps-https${count.index}"
-  port     = 10443
-  protocol = "HTTPS"
-  vpc_id   = module.stack.vpc_id
-
-  health_check {
-    healthy_threshold   = 2
-    interval            = 5
-    port                = 8443
-    timeout             = 4
-    unhealthy_threshold = 3
-    matcher             = 200
-    protocol            = "HTTPS"
-    path                = "/health"
-  }
-}
-
-resource "aws_lb_target_group" "domains_broker_gr_logstash_https" {
-  count = var.domains_broker_alb_count
-
-  name     = "${var.stack_description}-domains-glogstash-${count.index}"
   port     = 10443
   protocol = "HTTPS"
   vpc_id   = module.stack.vpc_id


### PR DESCRIPTION
## Changes proposed in this pull request:

- [remove custom logstash listener by host on old domains broker LBs](https://github.com/cloud-gov/terraform-provision/commit/97d22d45e32ef02b9a7b5e4fc71646ab85aefaa3). These rules are no longer used since this traffic travels over different LBs.
- [remove unused target groups](https://github.com/cloud-gov/terraform-provision/commit/3aaba99005d413ee38159d697c509c25be44e162). These target groups are no longer used since the traffic goes over different LBs and into different target groups. This was verified by querying Cloudwatch metrics to confirm that these target groups have processed 0 requests for the last month.

## security considerations

This infrastructure is unused, so deleting it is actually an improvement for maintenance and thus security.
