### PR TITLE
remove alarms on 4xx rates for non-production environments

### DIFF
--- a/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "lb_4XX_anomaly_detection" {
-  count = var.domains_lbgroup_count
+  count = var.stack_description == "production" ? var.domains_lbgroup_count : 0
 
   alarm_name                = "${aws_lb.domains_lbgroup[count.index].arn_suffix} - Load Balancer High 4XX Response Rate"
   comparison_operator       = "GreaterThanUpperThreshold"


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove alarms on 4xx rates for non-production environments since no critical customer workloads actually run in those environments. Also alarms in these environments have a high false positive rate since traffic is sporadic, which makes it hard for Cloudwatch to build a model of expected 4xx error rates

## security considerations

We are removing these alarms for development and staging environments, but no critical workloads run on these load balancers in those environments, so it is not critical to monitor their 4xx error rates

