### PR TITLE
Update 4xx error alarms

### DIFF
--- a/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
@@ -1,17 +1,14 @@
 resource "aws_cloudwatch_metric_alarm" "lb_4XX_anomaly_detection" {
   count = var.domains_lbgroup_count
 
-  alarm_name                = "${aws_lb.domains_lbgroup[count.index].arn_suffix} - Load Balancer High 4XX Response Rate"
-  comparison_operator       = "GreaterThanUpperThreshold"
-  evaluation_periods        = 5
-  datapoints_to_alarm       = 3
-  threshold_metric_id       = "ad1"
-  alarm_description         = "Alerts when the targets are returning a higher than normal rate of 4XX responses"
-  insufficient_data_actions = []
-  actions_enabled           = true
-  ok_actions                = []
-  alarm_actions             = [var.notifications_arn]
-  treat_missing_data        = "missing"
+  alarm_name          = "${aws_lb.domains_lbgroup[count.index].arn_suffix}-anomalous-4xx-error-rate"
+  comparison_operator = "GreaterThanUpperThreshold"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 3
+  threshold_metric_id = "ad1"
+  alarm_description   = "Alerts when the targets are returning a higher than normal rate of 4XX responses"
+  actions_enabled     = false
+  treat_missing_data  = "missing"
 
   metric_query {
     id          = "ad1"
@@ -34,4 +31,38 @@ resource "aws_cloudwatch_metric_alarm" "lb_4XX_anomaly_detection" {
       }
     }
   }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lb_4XX_minimum_threshold" {
+  count = var.domains_lbgroup_count
+
+  alarm_name          = "${aws_lb.domains_lbgroup[count.index].arn_suffix}-minimum-4xx-error-threshold"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  datapoints_to_alarm = 3
+  alarm_description   = "Alerts when the targets are returning more than a minimum threshold of 4XX responses"
+  actions_enabled     = false
+  treat_missing_data  = "missing"
+  threshold           = 100 # only alarm when there are > 100 4xx errors
+  period              = 60
+  metric_name         = "HTTPCode_Target_4XX_Count"
+  namespace           = "AWS/ApplicationELB"
+
+  dimensions = {
+    LoadBalancer = aws_lb.domains_lbgroup[count.index].arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_composite_alarm" "lb_4xx_composite_alarm" {
+  count = var.domains_lbgroup_count
+
+  alarm_description = "Alerts when the targets have a higher than expected rate of 4xx errors"
+  alarm_name        = "${aws_lb.domains_lbgroup[count.index].arn_suffix}-high-4xx-error-rate"
+
+  alarm_actions = [var.notifications_arn]
+
+  alarm_rule = <<EOF
+ALARM(${aws_cloudwatch_metric_alarm.lb_4XX_anomaly_detection[count.index].alarm_name}) OR
+ALARM(${aws_cloudwatch_metric_alarm.lb_4XX_minimum_threshold[count.index].alarm_name})
+EOF
 }

--- a/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
@@ -47,6 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "lb_4XX_minimum_threshold" {
   period              = 60
   metric_name         = "HTTPCode_Target_4XX_Count"
   namespace           = "AWS/ApplicationELB"
+  statistic           = "Maximum"
 
   dimensions = {
     LoadBalancer = aws_lb.domains_lbgroup[count.index].arn_suffix

--- a/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/cloudwatch.tf
@@ -62,8 +62,5 @@ resource "aws_cloudwatch_composite_alarm" "lb_4xx_composite_alarm" {
 
   alarm_actions = [var.notifications_arn]
 
-  alarm_rule = <<EOF
-ALARM(${aws_cloudwatch_metric_alarm.lb_4XX_anomaly_detection[count.index].alarm_name}) OR
-ALARM(${aws_cloudwatch_metric_alarm.lb_4XX_minimum_threshold[count.index].alarm_name})
-EOF
+  alarm_rule = "ALARM(${aws_cloudwatch_metric_alarm.lb_4XX_anomaly_detection[count.index].alarm_name}) AND ALARM(${aws_cloudwatch_metric_alarm.lb_4XX_minimum_threshold[count.index].alarm_name})"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update 4xx error alarms to be a composite alarm that only triggers when
  - Count of 4xx errors is above the anomaly detection band
  - Count of 4xx errors is above 100. 100 is a very arbitrary number, but we think that any meaningful spike in 4xx errors should exceed this value.

## security considerations

This is a refinement of alarms on 4xx error rates. These alarms are beneficial to security as they allow us to detect unusual traffic patterns.
