### PR TITLE
Add dns query logging to tooling 

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -397,3 +397,11 @@ module "smtp" {
   vpc_id              = module.stack.vpc_id
   ingress_cidr_blocks = var.smtp_ingress_cidr_blocks
 }
+
+module "dns_logging" {
+  source = "../../modules/dns_logging"
+
+  stack_description = var.stack_description
+  vpc_id            = module.stack.vpc_id
+  aws_partition     = data.aws_partition.current.partition
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Currently Route53 Resolver Query logging to CloudWatch only takes place for the Dev, Stage, and Prod VPCs. To ensure full coverage, the TF Code needs to be updated to enable query logging for the Tooling VPC as well.
- Part of https://github.com/cloud-gov/private/issues/2494  
-

## security considerations
Adds a cloudwatch log group for tooling which the other envs already have
