### PR TITLE
pages: Add test-cio-gov.pages-dev.cloud.gov

### DIFF
--- a/terraform/stacks/dns/pages.tf
+++ b/terraform/stacks/dns/pages.tf
@@ -299,4 +299,20 @@ resource "aws_route53_record" "cloud_gov__acme-challenge_test-wiab_pages-dev_clo
   records = ["_acme-challenge.test-wiab.pages-dev.cloud.gov.external-domains-production.cloud.gov."]
 }
 
+resource "aws_route53_record" "cloud_gov_test-cio-gov_pages-dev_cloud_gov" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "test-cio-gov.pages-dev.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["test-cio-gov.pages-dev.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov__acme-challenge_test-cio-gov_pages-dev_cloud_gov" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "_acme-challenge.test-cio-gov.pages-dev.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.test-cio-gov.pages-dev.cloud.gov.external-domains-production.cloud.gov."]
+}
+
 ## End Development ##


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add another testing domain `test-cio-gov.pages-dev.cloud.gov`

## security considerations
Adding a testing domain
