### PR TITLE
Undo special char

### DIFF
--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -471,8 +471,8 @@ module "csb_iam" {
 resource "random_password" "csb_rds_password" {
   length      = 32
   special     = false
-  min_special = 2
-  min_upper   = 5
+  min_special = 0 # InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.
+  min_upper   = 6
   min_numeric = 5
   min_lower   = 5
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Terraform `random_password` supports more special characters than what AWS RDS allows for.  Disabling this for now and modifying one of the other parameters to generate a new password
- Part of https://github.com/cloud-gov/private/issues/2592
-

## security considerations
Needed for stig compliance
