### PR TITLE
Add support for rds storage autoscaling for bosh and bosh credhub dbs

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -17,16 +17,18 @@ resource "aws_db_instance" "rds_database" {
 
   auto_minor_version_upgrade = true
 
-  db_name           = var.rds_db_name
-  allocated_storage = var.rds_db_size
-  storage_type      = var.rds_db_storage_type
-  iops              = var.rds_db_iops
-  instance_class    = var.rds_instance_type
+  db_name        = var.rds_db_name
+  instance_class = var.rds_instance_type
+
+  # Configure Storage
+  allocated_storage     = var.rds_db_size
+  max_allocated_storage = var.rds_db_max_size
+  storage_type          = var.rds_db_storage_type
+  storage_encrypted     = true
+  iops                  = var.rds_db_iops
 
   username = var.rds_username
   password = var.rds_password
-
-  storage_encrypted = true
 
   db_subnet_group_name   = var.rds_subnet_group
   vpc_security_group_ids = var.rds_security_groups

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -9,6 +9,11 @@ variable "rds_db_size" {
   default = 20
 }
 
+variable "rds_db_max_size" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
+}
+
 variable "rds_db_storage_type" {
   default = "gp3"
 }

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -44,6 +44,7 @@ module "rds" {
   stack_description               = var.stack_description
   rds_instance_type               = var.rds_instance_type
   rds_db_size                     = var.rds_db_size
+  rds_db_max_size                 = var.rds_db_max_size
   rds_db_engine                   = var.rds_db_engine
   rds_db_engine_version           = var.rds_db_engine_version
   rds_db_name                     = var.rds_db_name
@@ -66,6 +67,7 @@ module "credhub_rds" {
   rds_db_name                     = var.credhub_rds_db_name
   rds_instance_type               = var.credhub_rds_instance_type
   rds_db_size                     = var.credhub_rds_db_size
+  rds_db_max_size                 = var.credhub_rds_db_max_size
   rds_db_storage_type             = var.credhub_rds_db_storage_type
   rds_db_engine_version           = var.credhub_rds_db_engine_version
   rds_username                    = var.credhub_rds_username

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -55,6 +55,11 @@ variable "rds_db_size" {
   default = 20
 }
 
+variable "rds_db_max_size" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
+}
+
 variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
@@ -162,6 +167,11 @@ variable "credhub_rds_instance_type" {
 
 variable "credhub_rds_db_size" {
   default = 100
+}
+
+variable "credhub_rds_db_max_size" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
 }
 
 variable "credhub_rds_username" {

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -16,6 +16,7 @@ module "base" {
   rds_private_cidr_4                        = var.rds_private_cidr_4
   rds_instance_type                         = var.rds_instance_type
   rds_db_size                               = var.rds_db_size
+  rds_db_max_size                           = var.rds_db_max_size
   rds_db_name                               = var.rds_db_name
   rds_db_engine                             = var.rds_db_engine
   rds_db_engine_version                     = var.rds_db_engine_version
@@ -30,6 +31,8 @@ module "base" {
   bosh_default_ssh_public_key               = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts                = var.s3_gateway_policy_accounts
   cidr_blocks                               = var.cidr_blocks
+  credhub_rds_db_size                       = var.rds_db_size_bosh_credhub
+  credhub_rds_db_max_size                   = var.rds_db_max_size_bosh_credhub
   credhub_rds_db_engine_version             = var.rds_db_engine_version_bosh_credhub
   credhub_rds_parameter_group_family        = var.rds_parameter_group_family_bosh_credhub
   rds_shared_preload_libraries_bosh_credhub = var.rds_shared_preload_libraries_bosh_credhub

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -55,6 +55,11 @@ variable "rds_db_size" {
   default = 20
 }
 
+variable "rds_db_max_size" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
+}
+
 variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
@@ -102,6 +107,15 @@ variable "rds_password" {
 
 variable "credhub_rds_password" {
   sensitive = true
+}
+
+variable "rds_db_size_bosh_credhub" {
+  default = 100
+}
+
+variable "rds_db_max_size_bosh_credhub" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
 }
 
 variable "target_vpc_id" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -192,6 +192,7 @@ module "stack" {
   az2                                       = data.aws_availability_zones.available.names[var.az2_index]
   aws_default_region                        = var.aws_default_region
   rds_db_size                               = var.rds_db_size
+  rds_db_max_size                           = var.rds_db_max_size
   rds_apply_immediately                     = var.rds_apply_immediately
   rds_allow_major_version_upgrade           = var.rds_allow_major_version_upgrade
   rds_instance_type                         = var.rds_instance_type
@@ -209,6 +210,8 @@ module "stack" {
   restricted_ingress_web_ipv6_cidrs         = var.restricted_ingress_web_ipv6_cidrs
   rds_password                              = var.rds_password
   credhub_rds_password                      = var.credhub_rds_password
+  rds_db_size_bosh_credhub                  = var.rds_db_size_bosh_credhub
+  rds_db_max_size_bosh_credhub              = var.rds_db_max_size_bosh_credhub
   rds_db_engine_version_bosh_credhub        = var.rds_db_engine_version_bosh_credhub
   rds_parameter_group_family_bosh_credhub   = var.rds_parameter_group_family_bosh_credhub
   rds_shared_preload_libraries_bosh_credhub = var.rds_shared_preload_libraries_bosh_credhub

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -16,6 +16,12 @@ variable "rds_db_size" {
   default = 20
 }
 
+variable "rds_db_max_size" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
+}
+
+
 variable "rds_password" {
   sensitive = true
 }
@@ -290,6 +296,15 @@ variable "loadbalancer_forward_new_weight" {
   default     = 0
 }
 
+
+variable "rds_db_size_bosh_credhub" {
+  default = 100
+}
+
+variable "rds_db_max_size_bosh_credhub" {
+  description = "Set to a value larger than rds_db_size to enable storage autoscaling. Setting to null disables storage autoscaling, similar to iops."
+  default     = null
+}
 
 variable "rds_db_engine_version_bosh_credhub" {
   default = "15.5"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add support for rds storage autoscaling for bosh and bosh credhub dbs
- If `max_allocated_storage` is not null and a value greater than `allocated_storage`, autoscaling of storage is enabled
- The default is null, so without overriding this with a TF_VAR_ value from the pipeline, this should be a no-op

## security considerations
This enables storage scaling, should have no security impacts.
