### PR TITLE
Configure dev bosh rds for autoscaled storage up to 40GB

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -718,6 +718,7 @@ jobs:
           TF_VAR_vpc_cidr: ((development_vpc_cidr))
           TF_VAR_rds_db_engine_version: "15.12"
           TF_VAR_rds_parameter_group_family: "postgres15"
+          TF_VAR_rds_db_max_size: 40
 
           TF_VAR_rds_shared_preload_libraries_bosh: "pgaudit,pg_stat_statements"
           TF_VAR_rds_pgaudit_log_values_bosh: "ddl,role"


### PR DESCRIPTION
## Changes proposed in this pull request:
- This change leverages https://github.com/cloud-gov/terraform-provision/pull/2226 to configure storage autoscaling for the dev BOSH director's RDS instance.  The current size is 20GB but can now scale automatically, if needed, to 40GB
- The change did not take the db offline while it was performed.
-

## security considerations
No security changes, allows a disk to scale in RDS
