### PR TITLE
Delegate workshop.cloud.gov to GitLab managed Cloudflare DNS

### DIFF
--- a/terraform/stacks/dns/workshop.tf
+++ b/terraform/stacks/dns/workshop.tf
@@ -1,19 +1,15 @@
 #########################################
 ## Production                          ##
-## pointers to gsa.gitlab-dedicated.us ##
+## delegation of workshop.cloud.gov to ##
+## CloudFlare NSes managed by GitLab   ##
 #########################################
-resource "aws_route53_record" "cloud_gov_workshop_cloud_gov_cname" {
+resource "aws_route53_record" "cloud_gov_workshop_cloud_gov_ns" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "workshop.cloud.gov."
-  type    = "CNAME"
-  ttl     = 60
-  records = ["gsa.gitlab-dedicated.us."]
-}
-
-resource "aws_route53_record" "cloud_gov_registry_workshop_cloud_gov_cname" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "registry.workshop.cloud.gov."
-  type    = "CNAME"
-  ttl     = 60
-  records = ["registry.gsa.gitlab-dedicated.us."]
+  type    = "NS"
+  ttl     = 10 # TODO - Bump to 1 hour once things are stable
+  records = [
+    "karl.ns.cloudflare.com.",
+    "tina.ns.cloudflare.com.",
+  ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
Addresses the Route53 needs for https://gsa.gitlab-dedicated.us/workshop/devtools-program/-/issues/286

- Removes the CNAMEs previously in place for workshop.cloud.gov
- Adds NS records delegating workshop.cloud.gov to GitLab managed Cloudflare DNS - This is required for the Bring Your Own Domain functionality of GitLab Dedicted for Government.

Nameservers:
~~~
karl.ns.cloudflare.com
tina.ns.cloudflare.com
~~~

## security considerations

This change has been discussed with the Cybersecurity team in https://gsa-tts.slack.com/archives/C07M3EFS59T/p1758042965055159

GitLab Dedicated for Government's CRM marks SC-20 as "inheritable" for customers, specifying scope as the domain `gitlab-dedicated.us` with the control implemented with DNSSEC.

The `cloud.gov` domain not have DNSSEC enabled, as such a subdomain configured for DNSSEC would have a broken trust chain.

GitLab asked FedRAMP (specifically GSA as the initial authorizer) for a SC-20 deviation for customers using bring your own domain (BYOD). This deviation was approved.  [gdg_byod_sc20_alt_approval-20250930.pdf](https://github.com/user-attachments/files/22726883/gdg_byod_sc20_alt_approval-20250930.pdf)

With that deviation approved, SC-20 for `workshop.cloud.gov` is covered instead by Cloud.gov's SC-20 implementation: HSTS preload requiring use of HTTPS for all web traffic to `*.cloud.gov` and blanket use of TLS for all exposed HTTP endpoints.

This change only delegates `workshop.cloud.gov` to the GitLab managed DNS servers and sets the NS TTL to 1 hour as a contingency to allow Cloud.gov to de-delegate the subdomain completely within 1 hour if needed.