### PR TITLE
add lifecycle policy to remove images if not pulled in 2 weeks

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -49,7 +49,20 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
             "action": {
                 "type": "expire"
             }
-        }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Expire images not pulled in 2 weeks",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "sinceImagePulled",
+                "countUnit": "days",
+                "countNumber": 14
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
     ]
   }
   EOF

--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -62,7 +62,7 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
             "action": {
                 "type": "expire"
             }
-        },
+        }
     ]
   }
   EOF


### PR DESCRIPTION
## Changes proposed in this pull request:
- Based on discussion with the engineering team this ECR Lifecycle policy rule will remove images if they have not been pulled in 2 weeks

## security considerations
Removing old images will keep us from using them when they may have vulnerabilities that have not been fixed.