### PR TITLE
modify ecr policy for transitioning image

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -74,8 +74,7 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
                 "countNumber": 90
             },
             "action": {
-                "type": "transition",
-                "targetStorageClass": "archive"
+                "type": "expire"
             }
         }
     ]

--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -52,7 +52,7 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
         },
         {
             "rulePriority": 2,
-            "description": "Expire images not pulled in 2 weeks",
+            "description": "Archive images not pulled in 2 weeks",
             "selection": {
                 "tagStatus": "any",
                 "countType": "sinceImagePulled",
@@ -60,7 +60,22 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
                 "countNumber": 14
             },
             "action": {
-                "type": "expire"
+                "type": "transition",
+                "targetStorageClass": "archive"
+            }
+        },
+        {
+            "rulePriority": 3,
+            "description": "Expire images archived for 90 days",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "sinceImageTransitioned",
+                "countUnit": "days",
+                "countNumber": 90
+            },
+            "action": {
+                "type": "transition",
+                "targetStorageClass": "archive"
             }
         }
     ]


### PR DESCRIPTION
## Changes proposed in this pull request:
- You can only archive images when using the `sinceImagePulled` count type.
- This updates the ecr policy to archive these images instead
- Archived images are required to exist for 90 days before they can be expired, so this adds a third rule to expire those images at 90 days
- The storage costs for archived images is 10 cents per GB, for the first 150 TB/month. These images are small so there shouldn't be any large increase in costs.

## security considerations
Updating ECR lifecycle to cycle out old images
