### PR TITLE
missed the storageClass option

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -69,6 +69,7 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
             "description": "Expire images archived for 90 days",
             "selection": {
                 "tagStatus": "any",
+                "storageClass": "archive",
                 "countType": "sinceImageTransitioned",
                 "countUnit": "days",
                 "countNumber": 90


### PR DESCRIPTION
## Changes proposed in this pull request:
- Missed setting the storageClass for the archive deletion rule

## security considerations
None, just fixing the lifecycle policy rule
