### PR TITLE
add scanning users for databases

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -864,6 +864,8 @@ jobs:
                     TERRAFORM_DB_HOST_FIELD: bosh_rds_host_curr
                     TERRAFORM_DB_USERNAME_FIELD: bosh_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: bosh_rds_password
+                    DB_SCANNER_USERNAME_FIELD: ((development_bosh_scanner_user))
+                    DB_SCANNER_PASSWORD_FIELD: ((development_bosh_scanner_pass))
                   run:
                     path: sh
                     args:
@@ -884,6 +886,8 @@ jobs:
                     TERRAFORM_DB_HOST_FIELD: credhub_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: credhub_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: credhub_rds_password
+                    DB_SCANNER_USERNAME_FIELD: ((development_credhub_scanner_user))
+                    DB_SCANNER_PASSWORD_FIELD: ((development_credhub_scanner_pass))
                   run:
                     path: sh
                     args:
@@ -905,6 +909,8 @@ jobs:
                     TERRAFORM_DB_HOST_FIELD: cf_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_rds_password
+                    DB_SCANNER_USERNAME_FIELD: ((development_cf_scanner_user))
+                    DB_SCANNER_PASSWORD_FIELD: ((development_cf_scanner_pass))
                   run:
                     path: sh
                     args:
@@ -926,6 +932,8 @@ jobs:
                     TERRAFORM_DB_HOST_FIELD: cf_as_rds_host
                     TERRAFORM_DB_USERNAME_FIELD: cf_as_rds_username
                     TERRAFORM_DB_PASSWORD_FIELD: cf_as_rds_password
+                    DB_SCANNER_USERNAME_FIELD: ((development_cf_as_scanner_user))
+                    DB_SCANNER_PASSWORD_FIELD: ((development_cf_as_scanner_pass))
                   run:
                     path: sh
                     args:

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -59,9 +59,9 @@ for db in ${DATABASES}; do
 			        ALTER ROLE ${db_scanner_user} WITH PASSWORD '${db_scanner_pass}';
 			      END IF;
 
-			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user}";
-			      GRANT SELECT ON ALL TABLE IN SCHEMA public TO ${db_scanner_user}";
-			      GRANT pg_read_all_settings TO ${db_scanner_user}";
+			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user};
+			      GRANT SELECT ON ALL TABLE IN SCHEMA public TO ${db_scanner_user};
+			      GRANT pg_read_all_settings TO ${db_scanner_user};
 			    COMMIT;
 		EOT
 	fi

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -8,6 +8,8 @@ TERRAFORM="${TERRAFORM_BIN:-terraform}"
 db_address=$(${TERRAFORM} output -raw -state="${STATE_FILE_PATH}" "${TERRAFORM_DB_HOST_FIELD}")
 db_user=$(${TERRAFORM} output -raw -state="${STATE_FILE_PATH}" "${TERRAFORM_DB_USERNAME_FIELD}")
 db_pass=$(${TERRAFORM} output -raw -state="${STATE_FILE_PATH}" "${TERRAFORM_DB_PASSWORD_FIELD}")
+db_scanner_user="${DB_SCANNER_USERNAME_FIELD}"
+db_scanner_pass="${DB_SCANNER_PASSWORD_FIELD}"
 
 export PGPASSWORD="${db_pass:?}"
 
@@ -19,98 +21,112 @@ psql_adm() { psql -h "${db_address}" -U "${db_user}" "$@"; }
 # Returns 0 if the specified string contains the specified substring,
 # otherwise returns 1.
 contains() {
-    string="$1"
-    substring="$2"
-    if test "${string#*"$substring"}" != "$string"
-    then
-        return 0    # $substring is in $string
-    else
-        return 1    # $substring is not in $string
-    fi
+	string="$1"
+	substring="$2"
+	if test "${string#*"$substring"}" != "$string"; then
+		return 0 # $substring is in $string
+	else
+		return 1 # $substring is not in $string
+	fi
 }
 
 # Make sure that we create a default database for the db_user
 # PG will assume a database named like the db_user if one is not specified.
 if ! contains "$DATABASES" "$db_user"; then
-  DATABASES="$db_user $DATABASES"
+	DATABASES="$db_user $DATABASES"
 fi
-
-
 
 for db in ${DATABASES}; do
 
-  # Create database
-  psql_adm -d postgres -l | awk '{print $1}' | grep -q "${db}" || \
-    psql_adm -d postgres -c "CREATE DATABASE ${db} OWNER ${db_user}"
-  # Enable extensions
-  for ext in ${EXTENSIONS}; do
-    psql_adm -d "${db}" -c "CREATE EXTENSION IF NOT EXISTS \"${ext}\""
-  done
+	# Create database
+	psql_adm -d postgres -l | awk '{print $1}' | grep -q "${db}" ||
+		psql_adm -d postgres -c "CREATE DATABASE ${db} OWNER ${db_user}"
+	# Enable extensions
+	for ext in ${EXTENSIONS}; do
+		psql_adm -d "${db}" -c "CREATE EXTENSION IF NOT EXISTS \"${ext}\""
+	done
 
-  # Remove default privileges
-  psql_adm -d "${db}" -c "REVOKE ALL ON SCHEMA public FROM PUBLIC"
+	# Remove default privileges
+	psql_adm -d "${db}" -c "REVOKE ALL ON SCHEMA public FROM PUBLIC"
 
-  # Special case for uaadb, create totp seed table for use with MFA
-  # Special case for Shibboleth, create storage records table for use with multi-zone Shibboleth
-  # Special case for Shibboleth, create function and trigger that verifies origin uaa is set to cloud.gov IdP
-  # Special case for Shibboelth, create FK between totp_seed and users and CASCADE on delete
-  if [ "${db}" = "uaadb" ]; then
-    psql_adm -d "${db}" <<-EOT
-    BEGIN;
-      CREATE TABLE IF NOT EXISTS totp_seed
-        (
-          username varchar(255) PRIMARY KEY,
-          seed varchar(36),
-          backup_code varchar(36)
-        );
-    COMMIT;
-EOT
+	# Create scan user if it does not exist and grant permissions needed for scans
+	if [ -n "${db_scanner_user}" ] && [ -n "${db_scanner_pass}" ]; then
+		psql_adm -d "${db}" <<-EOT
+			    BEGIN;
+			      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${db_scanner_user}') THEN
+			        CREATE ROLE ${db_scanner_user} WITH LOGIN PASSWORD '${db_scanner_pass}';
+			      ELSE
+			        ALTER ROLE ${db_scanner_user} WITH PASSWORD '${db_scanner_pass}';
+			      END IF;
 
-    psql_adm -d "${db}" <<-EOT
-      CREATE TABLE IF NOT EXISTS storagerecords
-        (
-          context varchar(255) NOT NULL,
-          id varchar(255) NOT NULL,
-          expires bigint DEFAULT NULL,
-          value text NOT NULL,
-          version bigint NOT NULL,
-          PRIMARY KEY (context, id)
-        )
-EOT
+			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user}";
+			      GRANT SELECT ON ALL TABLE IN SCHEMA public TO ${db_scanner_user}";
+			      GRANT pg_read_all_settings TO ${db_scanner_user}";
+			    COMMIT;
+		EOT
+	fi
 
-    # Enforce cloud.gov origin for IdP users by validating that their username
-    # is a valid email address, that their origin is set to `uaa` that they have
-    # been verified and that their created date does not match their password
-    # last modified date which only occurs for users who have been invited and
-    # haven't logged in for the first time and created their password.
-    psql_adm -d "${db}" <<-EOT
-      BEGIN;
-      CREATE OR REPLACE FUNCTION "f_isValidEmail"( text ) RETURNS BOOLEAN AS '
-      SELECT \$1 ~ ''^[^@\s]+@[^@\s]+(\.[^@\s]+)+$'' AS RESULT
-      ' LANGUAGE sql;
-      CREATE OR REPLACE FUNCTION "f_enforceCloudGovOrigin"() RETURNS TRIGGER AS \$\$
-      BEGIN
-        UPDATE users
-          SET ( origin, external_id ) = ( 'cloud.gov', username )
-          WHERE "f_isValidEmail"( username ) AND
-            origin = 'uaa' AND
-            verified = true;
-        RETURN null;
-      END;
-      \$\$ LANGUAGE plpgsql;
-      COMMIT;
-EOT
-    psql_adm -d "${db}" <<-EOT
-      BEGIN;
-      DROP TRIGGER IF EXISTS enforce_cloud_gov_idp_origin_trigger
-        ON users;
-      CREATE TRIGGER enforce_cloud_gov_idp_origin_trigger
-        AFTER UPDATE ON users
-        FOR EACH ROW
-        WHEN ( OLD.passwd_lastmodified IS DISTINCT FROM NEW.passwd_lastmodified )
-        EXECUTE PROCEDURE "f_enforceCloudGovOrigin"();
-      COMMIT;
-EOT
-  fi
+	# Special case for uaadb, create totp seed table for use with MFA
+	# Special case for Shibboleth, create storage records table for use with multi-zone Shibboleth
+	# Special case for Shibboleth, create function and trigger that verifies origin uaa is set to cloud.gov IdP
+	# Special case for Shibboelth, create FK between totp_seed and users and CASCADE on delete
+	if [ "${db}" = "uaadb" ]; then
+		psql_adm -d "${db}" <<-EOT
+			    BEGIN;
+			      CREATE TABLE IF NOT EXISTS totp_seed
+			        (
+			          username varchar(255) PRIMARY KEY,
+			          seed varchar(36),
+			          backup_code varchar(36)
+			        );
+			    COMMIT;
+		EOT
+
+		psql_adm -d "${db}" <<-EOT
+			      CREATE TABLE IF NOT EXISTS storagerecords
+			        (
+			          context varchar(255) NOT NULL,
+			          id varchar(255) NOT NULL,
+			          expires bigint DEFAULT NULL,
+			          value text NOT NULL,
+			          version bigint NOT NULL,
+			          PRIMARY KEY (context, id)
+			        )
+		EOT
+
+		# Enforce cloud.gov origin for IdP users by validating that their username
+		# is a valid email address, that their origin is set to `uaa` that they have
+		# been verified and that their created date does not match their password
+		# last modified date which only occurs for users who have been invited and
+		# haven't logged in for the first time and created their password.
+		psql_adm -d "${db}" <<-EOT
+			      BEGIN;
+			      CREATE OR REPLACE FUNCTION "f_isValidEmail"( text ) RETURNS BOOLEAN AS '
+			      SELECT \$1 ~ ''^[^@\s]+@[^@\s]+(\.[^@\s]+)+$'' AS RESULT
+			      ' LANGUAGE sql;
+			      CREATE OR REPLACE FUNCTION "f_enforceCloudGovOrigin"() RETURNS TRIGGER AS \$\$
+			      BEGIN
+			        UPDATE users
+			          SET ( origin, external_id ) = ( 'cloud.gov', username )
+			          WHERE "f_isValidEmail"( username ) AND
+			            origin = 'uaa' AND
+			            verified = true;
+			        RETURN null;
+			      END;
+			      \$\$ LANGUAGE plpgsql;
+			      COMMIT;
+		EOT
+		psql_adm -d "${db}" <<-EOT
+			      BEGIN;
+			      DROP TRIGGER IF EXISTS enforce_cloud_gov_idp_origin_trigger
+			        ON users;
+			      CREATE TRIGGER enforce_cloud_gov_idp_origin_trigger
+			        AFTER UPDATE ON users
+			        FOR EACH ROW
+			        WHEN ( OLD.passwd_lastmodified IS DISTINCT FROM NEW.passwd_lastmodified )
+			        EXECUTE PROCEDURE "f_enforceCloudGovOrigin"();
+			      COMMIT;
+		EOT
+	fi
 
 done

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -53,18 +53,18 @@ for db in ${DATABASES}; do
 	if [ -n "${db_scanner_user}" ] && [ -n "${db_scanner_pass}" ]; then
 		psql_adm -d "${db}" <<-EOT
 			    BEGIN;
-			          DO \$\$
-			            BEGIN
+			      DO \$\$
+			        BEGIN
 			      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${db_scanner_user}') THEN
 			        CREATE ROLE ${db_scanner_user} WITH LOGIN PASSWORD '${db_scanner_pass}';
 			      ELSE
 			        ALTER ROLE ${db_scanner_user} WITH PASSWORD '${db_scanner_pass}';
 			      END IF;
+			      END \$\$ LANGUAGE plpgsql;
 
 			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user};
 			      GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${db_scanner_user};
 			      GRANT pg_read_all_settings TO ${db_scanner_user};
-			          END \$\$ LANGUAGE plpgsql;
 			            END;
 			    COMMIT;
 		EOT

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -65,7 +65,8 @@ for db in ${DATABASES}; do
 			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user};
 			      GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${db_scanner_user};
 			      GRANT pg_read_all_settings TO ${db_scanner_user};
-			            END;
+			      ALTER DEFAULT PRIVILEGES FOR USER ${db_user} IN SCHEMA public GRANT SELECT ON TABLES TO ${db_scanner_user};
+			      END;
 			    COMMIT;
 		EOT
 	fi

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -64,7 +64,8 @@ for db in ${DATABASES}; do
 			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user};
 			      GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${db_scanner_user};
 			      GRANT pg_read_all_settings TO ${db_scanner_user};
-			          \$\$ LANGUAGE plpgsql;
+			          END \$\$ LANGUAGE plpgsql;
+			            END;
 			    COMMIT;
 		EOT
 	fi

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -53,6 +53,8 @@ for db in ${DATABASES}; do
 	if [ -n "${db_scanner_user}" ] && [ -n "${db_scanner_pass}" ]; then
 		psql_adm -d "${db}" <<-EOT
 			    BEGIN;
+			          DO \$\$
+			            BEGIN
 			      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${db_scanner_user}') THEN
 			        CREATE ROLE ${db_scanner_user} WITH LOGIN PASSWORD '${db_scanner_pass}';
 			      ELSE
@@ -60,8 +62,9 @@ for db in ${DATABASES}; do
 			      END IF;
 
 			      GRANT USAGE ON SCHEMA public TO ${db_scanner_user};
-			      GRANT SELECT ON ALL TABLE IN SCHEMA public TO ${db_scanner_user};
+			      GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${db_scanner_user};
 			      GRANT pg_read_all_settings TO ${db_scanner_user};
+			          \$\$ LANGUAGE plpgsql;
 			    COMMIT;
 		EOT
 	fi


### PR DESCRIPTION
## Changes proposed in this pull request:
- Creates database users for running our scans

## security considerations
Having separate users keeps the blast radius down if there is ever any compromise of accounts
