### PR TITLE
fix(rds_network): stop Oracle SG apply oscillation (drop inline ingress=[]/egress=[])

### DIFF
--- a/terraform/modules/rds_network/sg_oracle.tf
+++ b/terraform/modules/rds_network/sg_oracle.tf
@@ -10,14 +10,14 @@ resource "aws_security_group" "rds_oracle" {
   description = "Allow access to incoming Oracle traffic"
   vpc_id      = var.vpc_id
 
-  # Declare empty inline rule sets so Terraform actively removes any rules that
-  # were previously managed inline on this SG (notably the legacy plaintext 1521
-  # ingress). Without this, migrating from inline blocks to the standalone
-  # aws_security_group_rule resources below only ADDS the new rules and leaves the
-  # old inline ones orphaned on the live SG. All actual rules are managed as the
-  # standalone resources below (TCPS 2484 + egress only).
-  ingress = []
-  egress  = []
+  # Rules are managed exclusively by the standalone aws_security_group_rule
+  # resources below (matching sg_postgres.tf / sg_mysql.tf). Do NOT declare
+  # inline ingress/egress here — not even `= []`: an explicit empty inline set
+  # means "Terraform manages the inline rules and they must be empty", which
+  # fights the standalone rules and makes every apply oscillate (the SG resource
+  # deletes the standalone 2484 rule, the standalone resource re-creates it, …).
+  # Omitting them entirely leaves inline rules unmanaged so the standalone
+  # resources are the single source of truth.
 
   tags = {
     Name = "${var.stack_description} - Incoming Oracle Traffic"

--- a/terraform/modules/rds_network/tests/oracle_sg.tftest.hcl
+++ b/terraform/modules/rds_network/tests/oracle_sg.tftest.hcl
@@ -25,20 +25,12 @@ variables {
 run "oracle_sg_has_expected_rules" {
   command = plan
 
-  # --- SG exists ---
+  # --- SG exists. Rules are managed ONLY by the standalone aws_security_group_rule
+  #     resources below — the SG resource declares NO inline ingress/egress (see
+  #     sg_oracle.tf), which is what keeps applies from oscillating. ---
   assert {
     condition     = aws_security_group.rds_oracle.description == "Allow access to incoming Oracle traffic"
     error_message = "rds_oracle SG must exist with the expected description"
-  }
-
-  # --- SG owns empty inline rule sets so legacy inline rules (e.g. 1521) are removed ---
-  assert {
-    condition     = length(aws_security_group.rds_oracle.ingress) == 0
-    error_message = "rds_oracle must declare an empty inline ingress set (rules are standalone; forces removal of legacy inline rules)"
-  }
-  assert {
-    condition     = length(aws_security_group.rds_oracle.egress) == 0
-    error_message = "rds_oracle must declare an empty inline egress set (rules are standalone)"
   }
 
   # --- 2484 TCPS ingress rule (the only ingress — TLS-only) ---


### PR DESCRIPTION
## Problem

The dev Oracle security group has been **oscillating on every `apply-development`**, which broke TCPS 2484 connectivity and left plaintext 1521 open. From the apply logs (all on `main` — not a branch-pinning issue):

- **1237** (Aug 12): #2351 migration applied — inline rules removed, standalone `oracle_ingress_tcps` (2484) + `oracle_egress_default` created. Correct.
- **1241** (Aug 13): `aws_security_group.rds_oracle` updated in-place, **removed 2484** (`0 add, 1 change`).
- **1242**: standalone resources **re-created 2484** (`2 add`).
- **1243**: SG resource **stripped 2484 again** (`1 change`).

Each apply undoes the previous one — a permanent ping-pong. 2484 is absent after the odd builds (breaking connectivity); 1521 lingers because nothing standalone manages it once it drifts back.

## Root cause

`aws_security_group.rds_oracle` declared `ingress = []` / `egress = []` **while** the rules are also managed by standalone `aws_security_group_rule` resources. With the AWS provider these two modes must not coexist on one SG: an explicit empty inline set is **not** "unmanaged" — it means "Terraform manages the inline rules and they must be empty," so the SG resource deletes the standalone 2484 rule every apply and the standalone resource recreates it the next run.

`sg_postgres.tf` / `sg_mysql.tf` avoid this by **omitting** inline `ingress`/`egress` entirely. Oracle was the only SG with `ingress = []`.

This reverses the empty-inline approach from #2351 — that was an attempt to strip the legacy 1521 inline rule, but on a SG that also uses standalone rules it is the direct cause of the oscillation.

## Fix

- Remove `ingress = []` / `egress = []` from `aws_security_group.rds_oracle` so it stops managing inline rules; the standalone `oracle_ingress_tcps` (2484) + `oracle_egress_default` resources are the single source of truth (matching postgres/mysql).
- Update the `terraform test` to drop the now-incorrect empty-inline assertions.

## One-time operational cleanup (owned by Peter)

Once inline rules are unmanaged, Terraform will **not** remove the orphaned live **1521** ingress rule — it needs a one-time manual revoke on the dev Oracle SG. Peter is handling this cleanup (he has the SG ID).

Acceptance after cleanup: a follow-up `plan-development` shows **no** Oracle-SG add/change churn (oscillation resolved), and `describe-security-group-rules` shows **2484 ingress + egress only, no 1521**.

## Verification

- `terraform fmt` / `terraform validate` / `terraform test` (mock provider) green.

## Related

- Fixes the oscillation introduced by #2351.
- aws-broker#541 (TLS-only SG posture).