### PR TITLE
fix tagging permissions for broker 

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.tf
@@ -24,8 +24,7 @@ data "aws_iam_policy_document" "aws_broker_policy" {
       "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:db:cg-aws-broker-*",
       "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:og:cg-aws-broker-*",
       "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:subgrp:${var.rds_subgroup}",
-      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:pg:cg-aws-broker-*",
-      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:snapshot:cg-aws-broker-*"
+      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:pg:cg-aws-broker-*"
     ]
   }
 

--- a/terraform/modules/iam_role_policy/aws_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.tf
@@ -3,9 +3,6 @@ data "aws_iam_policy_document" "aws_broker_policy" {
     actions = [
       "rds:CreateDBInstance",
       "rds:ModifyDBInstance",
-      "rds:AddTagsToResource",
-      "rds:ListTagsForResource",
-      "rds:RemoveTagsFromResource",
       "rds:CreateDBInstanceReadReplica"
     ]
 
@@ -13,6 +10,22 @@ data "aws_iam_policy_document" "aws_broker_policy" {
       "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:db:cg-aws-broker-*",
       "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:og:cg-aws-broker-*",
       "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:subgrp:${var.rds_subgroup}"
+    ]
+  }
+
+  statement {
+    actions = [
+      "rds:AddTagsToResource",
+      "rds:ListTagsForResource",
+      "rds:RemoveTagsFromResource",
+    ]
+
+    resources = [
+      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:db:cg-aws-broker-*",
+      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:og:cg-aws-broker-*",
+      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:subgrp:${var.rds_subgroup}",
+      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:pg:cg-aws-broker-*",
+      "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:snapshot:cg-aws-broker-*"
     ]
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix tagging permissions for broker to allow tagging on parameter groups

## security considerations

These permissions are necessary for the broker's normal operation when creating and deleting parameter groups. The permissions are scoped to only the resources that the broker is managing
